### PR TITLE
Cache resolved typefaces to avoid repeated lookups

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -39,6 +39,7 @@ Conversion benchmarks for `dxpdf` using the test document:
 | 2026-03-20 | latest | 114.0 ms ± 1.3 ms | 111.0 ms | 117.8 ms | 18.8 MB | Rc\<Vec\<u8\>\> for images, Rc\<str\> for font families — no atomic overhead |
 | 2026-03-21 | pipeline | 118.4 ms ± 1.0 ms | 116.1 ms | 120.0 ms | 19.1 MB | Measure→layout→paint pipeline for all elements, shared measure_lines, after-table spacing fix, 86 unit tests |
 | 2026-03-21 | latest | 113.3 ms ± 1.4 ms | 111.9 ms | 118.0 ms | 19.3 MB | +hyperlinks (PDF link annotations), superscript/subscript, pctPosVOffset, unsupported feature warnings, 98 unit tests |
+| 2026-03-21 | v0.1.3 | 114.2 ms ± 0.6 ms | 113.3 ms | 115.3 ms | 19.3 MB | +char styles, paragraph borders, font-first resolution, field codes, 104 unit tests |
 
 ### Methodology
 

--- a/README.md
+++ b/README.md
@@ -256,11 +256,11 @@ Validated against ISO 29500 (Office Open XML). **34 features fully implemented, 
 
 Benchmarked on Apple M3 Max with `hyperfine` (20 runs, 3 warmup):
 
-| Metric | Value |
-|---|---|
-| Mean conversion time | **113 ms** |
-| Peak memory (RSS) | **19 MB** |
-| Test document | 3-page form with 11 tables, 2 images, 2 sections |
+| Document | Pages | Mean time | Peak RSS |
+|---|---|---|---|
+| 3-page form (11 tables, 2 images) | 3 | **114 ms** | 19 MB |
+| 7-page inspection report | 7 | **213 ms** | 24 MB |
+| 24-page product sheet | 24 | **648 ms** | 76 MB |
 
 See [BENCHMARKS.md](BENCHMARKS.md) for full history.
 

--- a/src/render/fonts.rs
+++ b/src/render/fonts.rs
@@ -1,4 +1,7 @@
-use skia_safe::{Font, FontMgr, FontStyle};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use skia_safe::{Font, FontMgr, FontStyle, Typeface};
 
 /// Open-source metric-compatible substitutes for proprietary fonts.
 /// Each entry maps a proprietary font name to a list of alternatives
@@ -27,9 +30,22 @@ const FONT_SUBSTITUTIONS: &[(&str, &[&str])] = &[
     ("Segoe UI", &["Noto Sans", "Liberation Sans"]),
 ];
 
+/// Cache key for resolved typefaces.
+#[derive(Hash, Eq, PartialEq)]
+struct TypefaceKey {
+    family: String,
+    weight: i32,
+    slant: skia_safe::font_style::Slant,
+}
+
+// Thread-local cache of resolved typefaces to avoid repeated fontconfig lookups.
+thread_local! {
+    static TYPEFACE_CACHE: RefCell<HashMap<TypefaceKey, Typeface>> = RefCell::new(HashMap::new());
+}
+
 /// Try to match a font by family name, returning it only if the system
 /// actually has that exact font (not a Skia-substituted fallback).
-fn match_exact(font_mgr: &FontMgr, family: &str, style: FontStyle) -> Option<skia_safe::Typeface> {
+fn match_exact(font_mgr: &FontMgr, family: &str, style: FontStyle) -> Option<Typeface> {
     let tf = font_mgr.match_family_style(family, style)?;
     // Skia may silently return a fallback font instead of None.
     // Verify the returned typeface actually matches the requested family.
@@ -43,11 +59,7 @@ fn match_exact(font_mgr: &FontMgr, family: &str, style: FontStyle) -> Option<ski
 
 /// Resolve a font family name, trying the requested font first, then
 /// metric-compatible substitutes from the table, then Helvetica as a final fallback.
-pub fn resolve_typeface(
-    font_mgr: &FontMgr,
-    font_family: &str,
-    style: FontStyle,
-) -> skia_safe::Typeface {
+fn resolve_typeface_uncached(font_mgr: &FontMgr, font_family: &str, style: FontStyle) -> Typeface {
     // Try the requested font first (exact match only)
     if let Some(tf) = match_exact(font_mgr, font_family, style) {
         return tf;
@@ -70,6 +82,26 @@ pub fn resolve_typeface(
         .match_family_style("Helvetica", style)
         .or_else(|| font_mgr.legacy_make_typeface(None::<&str>, style))
         .expect("no fallback typeface available")
+}
+
+/// Resolve a typeface with caching. Lookups are cached per (family, style)
+/// to avoid repeated fontconfig queries.
+pub fn resolve_typeface(font_mgr: &FontMgr, font_family: &str, style: FontStyle) -> Typeface {
+    let key = TypefaceKey {
+        family: font_family.to_lowercase(),
+        weight: *style.weight(),
+        slant: style.slant(),
+    };
+
+    TYPEFACE_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(tf) = cache.get(&key) {
+            return tf.clone();
+        }
+        let tf = resolve_typeface_uncached(font_mgr, font_family, style);
+        cache.insert(key, tf.clone());
+        tf
+    })
 }
 
 /// Create a Skia Font for the given properties with substitution support.


### PR DESCRIPTION
Add thread-local TYPEFACE_CACHE backed by a HashMap and a TypefaceKey; introduce resolve_typeface wrapper and resolve_typeface_uncached. Also update README and BENCHMARKS.md with new benchmark rows and table formatting