### PR TITLE
Make LayoutConfig internal and derive defaults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,7 @@ pub fn convert(docx_bytes: &[u8]) -> Result<Vec<u8>, Error> {
 pub fn convert_document(document: &model::Document) -> Result<Vec<u8>, Error> {
     let font_mgr = skia_safe::FontMgr::new();
     render::fonts::preload_fonts(&font_mgr, &document.font_families());
-    let config = render::layout::LayoutConfig::default();
-    let pages = render::layout::layout(document, &config, &font_mgr);
+    let pages = render::layout::layout(document, &font_mgr);
     render::painter::render_to_pdf_with_font_mgr(&pages, &font_mgr)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,7 @@ fn main() -> Result<(), dxpdf::Error> {
         let font_mgr = skia_safe::FontMgr::new();
         dxpdf::render::fonts::preload_fonts(&font_mgr, &document.font_families());
         let t_fonts = Instant::now();
-        let config = dxpdf::render::layout::LayoutConfig::default();
-        let pages = dxpdf::render::layout::layout(&document, &config, &font_mgr);
+        let pages = dxpdf::render::layout::layout(&document, &font_mgr);
         let t2 = Instant::now();
         let pdf_bytes = dxpdf::render::painter::render_to_pdf_with_font_mgr(&pages, &font_mgr)?;
         let t3 = Instant::now();

--- a/src/render/layout/mod.rs
+++ b/src/render/layout/mod.rs
@@ -13,6 +13,13 @@ use crate::model::*;
 use crate::units::*;
 use fragment::DocDefaultsLayout;
 
+/// US Letter page width in points (8.5 inches).
+const US_LETTER_WIDTH_PT: f32 = 612.0;
+/// US Letter page height in points (11 inches).
+const US_LETTER_HEIGHT_PT: f32 = 792.0;
+/// Default page margin in points (1 inch).
+const DEFAULT_PAGE_MARGIN_PT: f32 = 72.0;
+
 /// Pre-decoded Skia images keyed by relationship ID.
 /// All images are decoded upfront in `new()` — lookups are free.
 pub(crate) struct ImageCache {
@@ -44,8 +51,9 @@ impl ImageCache {
 }
 
 /// Page layout configuration in points (1 point = 1/72 inch).
+/// Built internally from document `SectionProperties`.
 #[derive(Debug, Clone, Copy)]
-pub struct LayoutConfig {
+pub(crate) struct LayoutConfig {
     pub page_width: f32,
     pub page_height: f32,
     pub margin_top: f32,
@@ -59,6 +67,11 @@ pub struct LayoutConfig {
 }
 
 impl Default for LayoutConfig {
+    /// US Letter (8.5 × 11 in) with 1-inch margins.
+    ///
+    /// OOXML (ISO/IEC 29500-1, §17.6.2) does not mandate `w:sectPr` on the
+    /// document body; when it is absent, consumers are expected to fall back
+    /// to application-defined defaults. These match Microsoft Word's defaults.
     fn default() -> Self {
         Self {
             page_width: US_LETTER_WIDTH_PT,
@@ -74,6 +87,14 @@ impl Default for LayoutConfig {
 }
 
 impl LayoutConfig {
+    /// Build a layout config from section properties, using US Letter defaults
+    /// for any values not specified.
+    fn from_section(sect: &SectionProperties) -> Self {
+        let mut cfg = Self::default();
+        apply_section_to_config(&mut cfg, sect);
+        cfg
+    }
+
     pub fn content_width(&self) -> f32 {
         self.page_width - self.margin_left - self.margin_right
     }
@@ -144,28 +165,24 @@ pub struct LayoutedPage {
 }
 
 /// Perform layout on a document, producing positioned draw commands per page.
-pub fn layout(
-    doc: &Document,
-    config: &LayoutConfig,
-    font_mgr: &skia_safe::FontMgr,
-) -> Vec<LayoutedPage> {
+///
+/// Page dimensions and margins are derived from the document's section properties,
+/// falling back to US Letter with 1-inch margins when not specified.
+pub fn layout(doc: &Document, font_mgr: &skia_safe::FontMgr) -> Vec<LayoutedPage> {
+    // Build per-section configs from inline section breaks + final section.
     let mut section_configs: Vec<LayoutConfig> = Vec::new();
     for block in &doc.blocks {
         if let Block::Paragraph(p) = block {
             if let Some(ref sect) = p.section_properties {
-                let mut cfg = *config;
-                apply_section_to_config(&mut cfg, sect);
-                section_configs.push(cfg);
+                section_configs.push(LayoutConfig::from_section(sect));
             }
         }
     }
     if let Some(ref sect) = doc.final_section {
-        let mut cfg = *config;
-        apply_section_to_config(&mut cfg, sect);
-        section_configs.push(cfg);
+        section_configs.push(LayoutConfig::from_section(sect));
     }
 
-    let initial_config = section_configs.first().copied().unwrap_or(*config);
+    let initial_config = section_configs.first().copied().unwrap_or_default();
     let mut next_configs = section_configs.into_iter().skip(1).collect::<Vec<_>>();
     next_configs.reverse();
 

--- a/src/render/layout/tests.rs
+++ b/src/render/layout/tests.rs
@@ -85,7 +85,7 @@ fn extract_lines(pages: &[LayoutedPage]) -> Vec<(f32, f32, f32, f32)> {
 #[test]
 fn layout_empty_document() {
     let doc = make_doc(vec![]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert_eq!(pages.len(), 1);
     assert!(pages[0].commands.is_empty());
 }
@@ -93,8 +93,7 @@ fn layout_empty_document() {
 #[test]
 fn layout_single_paragraph() {
     let doc = make_doc(vec![simple_paragraph("Hello World")]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert_eq!(pages.len(), 1);
     assert!(!pages[0].commands.is_empty());
     assert!(pages[0]
@@ -127,7 +126,7 @@ fn layout_page_break() {
         }));
     }
     let doc = make_doc(blocks);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert!(
         pages.len() > 1,
         "Expected multiple pages, got {}",
@@ -150,10 +149,9 @@ fn layout_centered_text() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     if let Some(DrawCommand::Text { x, .. }) = pages[0].commands.first() {
-        assert!(*x > config.margin_left);
+        assert!(*x > DEFAULT_PAGE_MARGIN_PT);
     }
 }
 
@@ -204,12 +202,11 @@ fn table_borders_simple_2x2() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
 
-    let margin = config.margin_left;
-    let scale = config.content_width() / 288.0;
+    let margin = DEFAULT_PAGE_MARGIN_PT;
+    let scale = (US_LETTER_WIDTH_PT - 2.0 * DEFAULT_PAGE_MARGIN_PT) / 288.0;
     let col_w = 144.0 * scale;
     let x_left = margin;
     let x_mid = margin + col_w;
@@ -245,12 +242,11 @@ fn table_borders_with_gridspan() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
 
-    let margin = config.margin_left;
-    let scale = config.content_width() / 300.0;
+    let margin = DEFAULT_PAGE_MARGIN_PT;
+    let scale = (US_LETTER_WIDTH_PT - 2.0 * DEFAULT_PAGE_MARGIN_PT) / 300.0;
     let col_w = 100.0 * scale;
     let x0 = margin;
     let x1 = margin + col_w;
@@ -304,13 +300,12 @@ fn table_borders_alignment_across_rows() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
 
-    let scale = config.content_width() / 200.0;
+    let scale = (US_LETTER_WIDTH_PT - 2.0 * DEFAULT_PAGE_MARGIN_PT) / 200.0;
     let cw = 50.0 * scale;
-    let margin = config.margin_left;
+    let margin = DEFAULT_PAGE_MARGIN_PT;
     let x_after_2cols = margin + 2.0 * cw;
 
     let v_count = lines
@@ -375,12 +370,11 @@ fn table_borders_tcw_vs_grid_alignment() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
 
-    let scale = config.content_width() / 30.0;
-    let margin = config.margin_left;
+    let scale = (US_LETTER_WIDTH_PT - 2.0 * DEFAULT_PAGE_MARGIN_PT) / 30.0;
+    let margin = DEFAULT_PAGE_MARGIN_PT;
     let boundary_12 = margin + 15.0 * scale;
 
     let v_at_boundary_row0 = lines
@@ -473,7 +467,7 @@ fn spacing_before_after_affects_position() {
         ],
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     assert!(texts.len() >= 2);
 
@@ -515,7 +509,7 @@ fn left_indentation_shifts_text_right() {
         ],
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
 
     let no_indent_x = texts.iter().find(|(_, _, t)| t == "NoIndent").unwrap().0;
@@ -577,7 +571,7 @@ fn section_break_changes_page_dimensions() {
         }),
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert!(pages.len() >= 2);
     assert!((pages[0].page_width - 612.0).abs() < 1.0);
     assert!((pages[0].page_height - 792.0).abs() < 1.0);
@@ -603,7 +597,7 @@ fn adjacent_tables_no_gap() {
         blocks: vec![Block::Table(mk_table("T1")), Block::Table(mk_table("T2"))],
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
     let mut h_ys: Vec<f32> = lines
         .iter()
@@ -655,7 +649,7 @@ fn vmerge_skips_content_and_border() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
 
     assert!(texts.iter().any(|(_, _, t)| t == "Merged"));
@@ -687,7 +681,7 @@ fn line_break_forces_new_line() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let before = texts.iter().find(|(_, _, t)| t == "Before").unwrap();
     let after = texts.iter().find(|(_, _, t)| t == "After").unwrap();
@@ -726,8 +720,7 @@ fn paragraph_shading_excludes_spacing() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let rects = extract_rects(&pages);
     let texts = extract_texts(&pages);
 
@@ -738,9 +731,9 @@ fn paragraph_shading_excludes_spacing() {
 
     // Rect should NOT start at margin_top (spacing.before pushes it down)
     assert!(
-        rect_top > config.margin_top,
+        rect_top > DEFAULT_PAGE_MARGIN_PT,
         "Rect top ({rect_top}) should be below margin ({}) due to spacing.before",
-        config.margin_top
+        DEFAULT_PAGE_MARGIN_PT
     );
     // Text should be within rect
     assert!(
@@ -777,7 +770,7 @@ fn row_height_minimum_respected() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
     let h_ys: Vec<f32> = lines
         .iter()
@@ -810,12 +803,11 @@ fn right_alignment() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let text_x = texts.iter().find(|(_, _, t)| t == "Right").unwrap().0;
     assert!(
-        text_x > config.margin_left + config.content_width() / 2.0,
+        text_x > DEFAULT_PAGE_MARGIN_PT + (US_LETTER_WIDTH_PT - 2.0 * DEFAULT_PAGE_MARGIN_PT) / 2.0,
         "Right-aligned text x ({text_x}) should be in right half"
     );
 }
@@ -1275,7 +1267,7 @@ fn vmerge_three_rows_distributes_height() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
 
     // Should have horizontal borders at 4 y-positions (top of each row + bottom)
@@ -1321,7 +1313,7 @@ fn vmerge_multiple_columns() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
 
     // Restart cells should render
@@ -1363,7 +1355,7 @@ fn spacing_defaults_applied_when_paragraph_has_none() {
         },
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let text_y = texts.iter().find(|(_, _, t)| t == "Test").unwrap().1;
     // Text should be below margin_top + before_spacing(5pt) + line_height
@@ -1402,7 +1394,7 @@ fn direct_spacing_overrides_defaults() {
         },
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let text_y = texts.iter().find(|(_, _, t)| t == "Test").unwrap().1;
     assert!(
@@ -1440,7 +1432,7 @@ fn paragraph_shading_split_across_pages() {
         section_properties: None,
     }));
     let doc = make_doc(blocks);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     // Should not panic — verify at least one page has rect commands
     let total_rects: usize = pages
         .iter()
@@ -1475,7 +1467,7 @@ fn table_splits_across_pages() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert!(
         pages.len() > 1,
         "Table should span multiple pages, got {} pages",
@@ -1517,7 +1509,7 @@ fn cell_margins_from_table_default() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let text = texts.iter().find(|(_, _, t)| t == "Content").unwrap();
     // Text should be offset from cell left edge by left margin (10pt)
@@ -1553,7 +1545,7 @@ fn cell_shading_produces_rect() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let rects = extract_rects(&pages);
     assert!(
         rects.iter().any(|(_, _, _, _, c)| *c == (200, 100, 50)),
@@ -1575,7 +1567,7 @@ fn empty_table_no_crash() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert_eq!(pages.len(), 1);
 }
 
@@ -1592,7 +1584,7 @@ fn single_cell_table() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     assert!(texts.iter().any(|(_, _, t)| t == "Only"));
 }
@@ -1621,7 +1613,7 @@ fn table_with_empty_cell() {
         borders: None,
     };
     let doc = make_doc(vec![Block::Table(table)]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     assert!(texts.iter().any(|(_, _, t)| t == "Filled"));
 }
@@ -1641,13 +1633,12 @@ fn empty_paragraph_still_has_height() {
         }),
         simple_paragraph("After"),
     ]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let after_y = texts.iter().find(|(_, _, t)| t == "After").unwrap().1;
     // Empty paragraph should push "After" down from margin_top
     assert!(
-        after_y > config.margin_top + 10.0,
+        after_y > DEFAULT_PAGE_MARGIN_PT + 10.0,
         "After y={after_y} should be pushed down by empty paragraph height"
     );
 }
@@ -1684,8 +1675,7 @@ fn first_line_indent_shifts_first_line_only() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let first_x = texts.iter().find(|(_, _, t)| t == "First").unwrap().0;
     let second_x = texts.iter().find(|(_, _, t)| t == "Second").unwrap().0;
@@ -1736,7 +1726,7 @@ fn bullet_list_renders_label() {
         },
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     assert!(
         texts.iter().any(|(_, _, t)| t == "•"),
@@ -1786,7 +1776,7 @@ fn decimal_list_increments_counter() {
         },
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     assert!(
         texts.iter().any(|(_, _, t)| t == "1."),
@@ -1832,16 +1822,15 @@ fn float_adjustment_shifts_text() {
         section_properties: None,
     })]);
     doc.images.insert("rId1".to_string(), TINY_PNG.to_vec());
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let text = texts.iter().find(|(_, _, t)| t == "FloatTest").unwrap();
     // Text should be shifted right of the float (100pt + gap)
     assert!(
-        text.0 > config.margin_left + 100.0,
+        text.0 > DEFAULT_PAGE_MARGIN_PT + 100.0,
         "Text x={} should be right of float (margin+100={})",
         text.0,
-        config.margin_left + 100.0
+        DEFAULT_PAGE_MARGIN_PT + 100.0
     );
 }
 
@@ -1871,7 +1860,7 @@ fn header_renders_on_each_page() {
         }),
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert!(pages.len() >= 2, "Need multiple pages");
     // Each page should have "HEADER" text
     for (i, page) in pages.iter().enumerate() {
@@ -1902,8 +1891,7 @@ fn footer_renders_at_bottom() {
         }),
         ..Document::default()
     };
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let footer = texts.iter().find(|(_, _, t)| t == "FOOTER").unwrap();
     let body = texts.iter().find(|(_, _, t)| t == "Body").unwrap();
@@ -1966,7 +1954,7 @@ fn after_table_spacing_uses_doc_default() {
         },
         ..Document::default()
     };
-    let pages_with = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages_with = layout(&doc, &test_font_mgr());
 
     let table2 = Table {
         rows: vec![TableRow {
@@ -1982,7 +1970,7 @@ fn after_table_spacing_uses_doc_default() {
         blocks: vec![Block::Table(table2), simple_paragraph("After")],
         ..Document::default()
     };
-    let pages_without = layout(&doc_no_sp, &LayoutConfig::default(), &test_font_mgr());
+    let pages_without = layout(&doc_no_sp, &test_font_mgr());
 
     let y_with = extract_texts(&pages_with)
         .iter()
@@ -2050,8 +2038,7 @@ fn pct_pos_offset_positions_float_by_page_percentage() {
         section_properties: None,
     })]);
     doc.images.insert("rId1".to_string(), TINY_PNG.to_vec());
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let imgs = extract_images(&pages);
     assert!(!imgs.is_empty(), "Should have an image");
     let (ix, iy, _, _) = imgs[0];
@@ -2086,8 +2073,7 @@ fn pct_pos_none_uses_regular_offset() {
         section_properties: None,
     })]);
     doc.images.insert("rId1".to_string(), TINY_PNG.to_vec());
-    let config = LayoutConfig::default();
-    let pages = layout(&doc, &config, &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let imgs = extract_images(&pages);
     let (ix, _iy, _, _) = imgs[0];
     // Should use margin_left + offset_x_pt = 72 + 20 = 92
@@ -2129,7 +2115,7 @@ fn hyperlink_produces_link_annotation() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let links = extract_link_annotations(&pages);
     assert_eq!(links.len(), 1, "Should have one link annotation");
     assert_eq!(links[0].4, "https://example.com");
@@ -2140,7 +2126,7 @@ fn hyperlink_produces_link_annotation() {
 #[test]
 fn no_hyperlink_no_annotation() {
     let doc = make_doc(vec![simple_paragraph("Plain text")]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let links = extract_link_annotations(&pages);
     assert!(links.is_empty(), "No hyperlinks, no annotations");
 }
@@ -2169,7 +2155,7 @@ fn paragraph_bottom_border_renders_line() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let lines = extract_lines(&pages);
     // Should have a horizontal line (bottom border)
     let h_lines: Vec<_> = lines
@@ -2224,7 +2210,7 @@ fn page_field_renders_page_number_in_footer() {
         }),
         ..Document::default()
     };
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     assert!(pages.len() >= 2, "Need multiple pages");
 
     // Page 1 footer should have "1" and total page count
@@ -2277,7 +2263,7 @@ fn superscript_reduces_font_size_and_shifts_up() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let normal = texts.iter().find(|(_, _, t)| t == "m").unwrap();
     let sup = texts.iter().find(|(_, _, t)| t == "2").unwrap();
@@ -2312,7 +2298,7 @@ fn subscript_shifts_down() {
         floats: Vec::new(),
         section_properties: None,
     })]);
-    let pages = layout(&doc, &LayoutConfig::default(), &test_font_mgr());
+    let pages = layout(&doc, &test_font_mgr());
     let texts = extract_texts(&pages);
     let normal = texts.iter().find(|(_, _, t)| t == "H").unwrap();
     let sub = texts.iter().find(|(_, _, t)| t == "2").unwrap();

--- a/src/units.rs
+++ b/src/units.rs
@@ -67,17 +67,6 @@ pub const WIDTH_TYPE_DXA: &str = "dxa";
 /// OOXML underline value for "no underline".
 pub const UNDERLINE_NONE: &str = "none";
 
-// --- Standard page dimensions ---
-
-/// US Letter page width in points (8.5 inches).
-pub const US_LETTER_WIDTH_PT: f32 = 612.0;
-
-/// US Letter page height in points (11 inches).
-pub const US_LETTER_HEIGHT_PT: f32 = 792.0;
-
-/// Default page margin in points (1 inch).
-pub const DEFAULT_PAGE_MARGIN_PT: f32 = 72.0;
-
 // --- Rendering defaults ---
 // These are not from the OOXML spec but are reasonable rendering choices.
 // TODO: FLOAT_TEXT_GAP_PT should be replaced by parsing wp:distL/distR/distT/distB

--- a/tests/api_compat.rs
+++ b/tests/api_compat.rs
@@ -63,10 +63,6 @@ fn unit_constants() {
     let _: &str = dxpdf::units::WIDTH_TYPE_DXA;
     let _: &str = dxpdf::units::UNDERLINE_NONE;
 
-    let _: f32 = dxpdf::units::US_LETTER_WIDTH_PT;
-    let _: f32 = dxpdf::units::US_LETTER_HEIGHT_PT;
-    let _: f32 = dxpdf::units::DEFAULT_PAGE_MARGIN_PT;
-
     let _: f32 = dxpdf::units::FLOAT_TEXT_GAP_PT;
     let _: f32 = dxpdf::units::MIN_TAB_WIDTH_PT;
     let _: f32 = dxpdf::units::TAB_FALLBACK_PT;
@@ -763,22 +759,6 @@ fn render_fonts_signatures() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn layout_config_fields_and_methods() {
-    use dxpdf::render::layout::LayoutConfig;
-    let cfg = LayoutConfig::default();
-    let _: f32 = cfg.page_width;
-    let _: f32 = cfg.page_height;
-    let _: f32 = cfg.margin_top;
-    let _: f32 = cfg.margin_bottom;
-    let _: f32 = cfg.margin_left;
-    let _: f32 = cfg.margin_right;
-    let _: f32 = cfg.header_margin;
-    let _: f32 = cfg.footer_margin;
-    let _: f32 = cfg.content_width();
-    let _: f32 = cfg.content_height();
-}
-
-#[test]
 fn layouted_page_fields() {
     use dxpdf::render::layout::{DrawCommand, LayoutedPage};
     let page = LayoutedPage {
@@ -846,7 +826,6 @@ fn layout_function_exists() {
     let _ = layout
         as fn(
             &dxpdf::model::Document,
-            &dxpdf::render::layout::LayoutConfig,
             &skia_safe::FontMgr,
         ) -> Vec<dxpdf::render::layout::LayoutedPage>;
 }


### PR DESCRIPTION
Make LayoutConfig pub(crate) and derive page size and margins from section
properties. Add US_LETTER_* and DEFAULT_PAGE_MARGIN_PT constants and LayoutConfig::from_section, and change layout() to build per-section configs
internally (drop the explicit config parameter). Remove exported page-size
constants from units.rs and update callers and tests to use the new API.