### PR TITLE
Add border space and align text baselines

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -520,6 +520,8 @@ pub struct BorderDef {
     /// Width in eighths of a point (OOXML native for `w:sz`).
     pub size: EighthPoints,
     pub color: Color,
+    /// Space between border and content in points (OOXML `w:space`).
+    pub space: Pt,
 }
 
 impl BorderDef {
@@ -533,6 +535,7 @@ impl BorderDef {
             style: BorderStyle::Single,
             size: EighthPoints::new(size),
             color,
+            space: Pt::ZERO,
         }
     }
 
@@ -548,6 +551,7 @@ impl Default for BorderDef {
             style: BorderStyle::Single,
             size: Self::DEFAULT_SIZE,
             color: Color::BLACK,
+            space: Pt::ZERO,
         }
     }
 }

--- a/src/parse/archive.rs
+++ b/src/parse/archive.rs
@@ -506,14 +506,25 @@ fn parse_doc_defaults(xml: &str) -> Option<DocDefaults> {
                         .find(|a| local_name(a.key.as_ref()) == b"color")
                         .map(|a| String::from_utf8_lossy(&a.value).into_owned())
                         .unwrap_or_default();
-                    let color =
-                        if color_str == "auto" || color_str.is_empty() {
-                            crate::model::Color { r: 0, g: 0, b: 0 }
-                        } else {
-                            crate::model::Color::from_hex(&color_str)
-                                .unwrap_or(crate::model::Color { r: 0, g: 0, b: 0 })
-                        };
-                    let def = crate::model::BorderDef { style, size, color };
+                    let color = if color_str == "auto" || color_str.is_empty() {
+                        crate::model::Color::BLACK
+                    } else {
+                        crate::model::Color::from_hex(&color_str)
+                            .unwrap_or(crate::model::Color::BLACK)
+                    };
+                    let space = e
+                        .attributes()
+                        .flatten()
+                        .find(|a| local_name(a.key.as_ref()) == b"space")
+                        .and_then(|a| String::from_utf8_lossy(&a.value).parse::<f32>().ok())
+                        .map(crate::dimension::Pt::new)
+                        .unwrap_or(crate::dimension::Pt::ZERO);
+                    let def = crate::model::BorderDef {
+                        style,
+                        size,
+                        color,
+                        space,
+                    };
                     let b = table_borders.get_or_insert(crate::model::TableBorders::default());
                     match local {
                         b"top" => b.top = def,

--- a/src/parse/xml/properties.rs
+++ b/src/parse/xml/properties.rs
@@ -27,12 +27,22 @@ pub fn parse_border_def(e: &quick_xml::events::BytesStart<'_>) -> Result<BorderD
 
     let color_str = get_attr(e, b"color")?.unwrap_or_default();
     let color = if color_str == "auto" || color_str.is_empty() {
-        Color { r: 0, g: 0, b: 0 }
+        Color::BLACK
     } else {
-        Color::from_hex(&color_str).unwrap_or(Color { r: 0, g: 0, b: 0 })
+        Color::from_hex(&color_str).unwrap_or(Color::BLACK)
     };
 
-    Ok(BorderDef { style, size, color })
+    let space = get_attr(e, b"space")?
+        .and_then(|v| v.parse::<f32>().ok())
+        .map(crate::dimension::Pt::new)
+        .unwrap_or(crate::dimension::Pt::ZERO);
+
+    Ok(BorderDef {
+        style,
+        size,
+        color,
+        space,
+    })
 }
 
 /// Apply a border element to the appropriate side of a TableBorders or CellBorders.

--- a/src/render/layout/fragment.rs
+++ b/src/render/layout/fragment.rs
@@ -53,6 +53,8 @@ pub enum Fragment {
         char_spacing_pt: Pt,
         measured_width: Pt,
         measured_height: Pt,
+        /// Distance from top of line box to baseline (always positive).
+        ascent: Pt,
         /// Hyperlink URL, if this text is part of a link.
         hyperlink_url: Option<String>,
         /// Baseline offset in points (negative = up for superscript, positive = down for subscript).
@@ -173,6 +175,7 @@ pub fn collect_fragments_with_fields(
                 };
 
                 let line_height = measurer.line_height(&font_family, base_font_size, bold, italic);
+                let ascent = measurer.ascent(&font_family, base_font_size, bold, italic);
                 for part in split_words_and_spaces(&tr.text) {
                     let base_width =
                         measurer.measure_width(part, &font_family, font_size, bold, italic);
@@ -196,6 +199,7 @@ pub fn collect_fragments_with_fields(
                         char_spacing_pt,
                         measured_width,
                         measured_height: line_height,
+                        ascent,
                         hyperlink_url: if is_space {
                             None
                         } else {
@@ -250,6 +254,7 @@ pub fn collect_fragments_with_fields(
                 let char_count = text.chars().count() as f32;
                 let measured_width = w + char_spacing_pt * char_count;
                 let lh = measurer.line_height(&font_family, font_size, bold, italic);
+                let ascent = measurer.ascent(&font_family, font_size, bold, italic);
                 fragments.push(Fragment::Text {
                     text,
                     font_family,
@@ -262,6 +267,7 @@ pub fn collect_fragments_with_fields(
                     char_spacing_pt,
                     measured_width,
                     measured_height: lh,
+                    ascent,
                     hyperlink_url: None,
                     baseline_offset: Pt::ZERO,
                 });
@@ -473,24 +479,22 @@ pub fn measure_lines(
                     shading,
                     char_spacing_pt,
                     measured_width,
+                    ascent,
                     hyperlink_url,
                     baseline_offset,
                     ..
                 } => {
                     let c = color.unwrap_or(Color::BLACK);
+                    let line_top = cursor_y - line_height;
+                    let baseline_y = line_top + *ascent;
                     if let Some(bg) = shading {
                         commands.push(DrawCommand::Rect {
-                            rect: PtRect::from_xywh(
-                                x,
-                                cursor_y - line_height,
-                                *measured_width,
-                                line_height,
-                            ),
+                            rect: PtRect::from_xywh(x, line_top, *measured_width, line_height),
                             color: *bg,
                         });
                     }
                     commands.push(DrawCommand::Text {
-                        position: PtOffset::new(x, cursor_y + *baseline_offset),
+                        position: PtOffset::new(x, baseline_y + *baseline_offset),
                         text: text.clone(),
                         font_family: font_family.clone(),
                         char_spacing_pt: *char_spacing_pt,
@@ -501,10 +505,11 @@ pub fn measure_lines(
                     });
                     if *underline {
                         let uw = underline_width(*font_size, *bold);
+                        let underline_y = baseline_y + UNDERLINE_Y_OFFSET;
                         commands.push(DrawCommand::Underline {
                             line: PtLineSegment::new(
-                                PtOffset::new(x, cursor_y + UNDERLINE_Y_OFFSET),
-                                PtOffset::new(x + *measured_width, cursor_y + UNDERLINE_Y_OFFSET),
+                                PtOffset::new(x, underline_y),
+                                PtOffset::new(x + *measured_width, underline_y),
                             ),
                             color: c,
                             width: uw,

--- a/src/render/layout/measurer.rs
+++ b/src/render/layout/measurer.rs
@@ -51,4 +51,12 @@ impl TextMeasurer {
         let (_, metrics) = font.metrics();
         Pt::new(-metrics.ascent + metrics.descent + metrics.leading)
     }
+
+    /// Get the ascent (distance from baseline to top of line) for a font.
+    /// Always positive.
+    pub fn ascent(&self, font_family: &str, font_size: Pt, bold: bool, italic: bool) -> Pt {
+        let font = fonts::make_font(&self.font_mgr, font_family, font_size, bold, italic);
+        let (_, metrics) = font.metrics();
+        Pt::new(-metrics.ascent)
+    }
 }

--- a/src/render/layout/paragraph.rs
+++ b/src/render/layout/paragraph.rs
@@ -69,8 +69,10 @@ impl Layouter {
                 false,
                 false,
             );
-            self.cursor_y += resolve_line_height(natural_height, spacing.line_spacing());
-            self.paint_paragraph_borders(&para.properties.paragraph_borders, top, self.cursor_y);
+            let line_h = resolve_line_height(natural_height, spacing.line_spacing());
+            // Paint borders before advancing — top border sits at paragraph start
+            self.paint_paragraph_borders(&para.properties.paragraph_borders, top, top + line_h);
+            self.cursor_y += line_h;
             self.cursor_y += spacing.after.map(Pt::from).unwrap_or(Pt::ZERO);
             return;
         }
@@ -223,11 +225,9 @@ impl Layouter {
             if let Some(ref b) = borders.top {
                 // Skip top border if previous paragraph already drew a border
                 if b.is_visible() && !self.prev_para_had_bottom_border {
+                    let y = top - b.space;
                     self.current_page.commands.push(DrawCommand::Line {
-                        line: PtLineSegment::new(
-                            PtOffset::new(left, top),
-                            PtOffset::new(right, top),
-                        ),
+                        line: PtLineSegment::new(PtOffset::new(left, y), PtOffset::new(right, y)),
                         color: b.color,
                         width: Pt::from(b.size),
                     });
@@ -235,11 +235,9 @@ impl Layouter {
             }
             if let Some(ref b) = borders.bottom {
                 if b.is_visible() {
+                    let y = bottom + b.space;
                     self.current_page.commands.push(DrawCommand::Line {
-                        line: PtLineSegment::new(
-                            PtOffset::new(left, bottom),
-                            PtOffset::new(right, bottom),
-                        ),
+                        line: PtLineSegment::new(PtOffset::new(left, y), PtOffset::new(right, y)),
                         color: b.color,
                         width: Pt::from(b.size),
                     });
@@ -247,11 +245,9 @@ impl Layouter {
             }
             if let Some(ref b) = borders.left {
                 if b.is_visible() {
+                    let x = left - b.space;
                     self.current_page.commands.push(DrawCommand::Line {
-                        line: PtLineSegment::new(
-                            PtOffset::new(left, top),
-                            PtOffset::new(left, bottom),
-                        ),
+                        line: PtLineSegment::new(PtOffset::new(x, top), PtOffset::new(x, bottom)),
                         color: b.color,
                         width: Pt::from(b.size),
                     });
@@ -259,11 +255,9 @@ impl Layouter {
             }
             if let Some(ref b) = borders.right {
                 if b.is_visible() {
+                    let x = right + b.space;
                     self.current_page.commands.push(DrawCommand::Line {
-                        line: PtLineSegment::new(
-                            PtOffset::new(right, top),
-                            PtOffset::new(right, bottom),
-                        ),
+                        line: PtLineSegment::new(PtOffset::new(x, top), PtOffset::new(x, bottom)),
                         color: b.color,
                         width: Pt::from(b.size),
                     });
@@ -393,24 +387,22 @@ impl Layouter {
                         shading,
                         char_spacing_pt,
                         measured_width,
+                        ascent,
                         hyperlink_url,
                         baseline_offset,
                         ..
                     } => {
                         let c = color.unwrap_or(Color::BLACK);
+                        let line_top = rel_y - line_height;
+                        let baseline_y = line_top + *ascent;
                         if let Some(bg) = shading {
                             commands.push(DrawCommand::Rect {
-                                rect: PtRect::from_xywh(
-                                    x,
-                                    rel_y - line_height,
-                                    *measured_width,
-                                    line_height,
-                                ),
+                                rect: PtRect::from_xywh(x, line_top, *measured_width, line_height),
                                 color: *bg,
                             });
                         }
                         commands.push(DrawCommand::Text {
-                            position: PtOffset::new(x, rel_y + *baseline_offset),
+                            position: PtOffset::new(x, baseline_y + *baseline_offset),
                             text: text.clone(),
                             font_family: font_family.clone(),
                             char_spacing_pt: *char_spacing_pt,
@@ -421,10 +413,11 @@ impl Layouter {
                         });
                         if *underline {
                             let uw = underline_width(*font_size, *bold);
+                            let underline_y = baseline_y + UNDERLINE_Y_OFFSET;
                             commands.push(DrawCommand::Underline {
                                 line: PtLineSegment::new(
-                                    PtOffset::new(x, rel_y + UNDERLINE_Y_OFFSET),
-                                    PtOffset::new(x + *measured_width, rel_y + UNDERLINE_Y_OFFSET),
+                                    PtOffset::new(x, underline_y),
+                                    PtOffset::new(x + *measured_width, underline_y),
                                 ),
                                 color: c,
                                 width: uw,

--- a/src/render/layout/tests.rs
+++ b/src/render/layout/tests.rs
@@ -888,6 +888,7 @@ fn make_text_frag(text: &str, width: f32) -> Fragment {
         char_spacing_pt: Pt::ZERO,
         measured_width: pt(width),
         measured_height: pt(14.0),
+        ascent: pt(11.0),
         hyperlink_url: None,
         baseline_offset: Pt::ZERO,
     }
@@ -1107,6 +1108,7 @@ fn measure_lines_with_underline() {
         char_spacing_pt: Pt::ZERO,
         measured_width: pt(60.0),
         measured_height: pt(14.0),
+        ascent: pt(11.0),
         hyperlink_url: None,
         baseline_offset: Pt::ZERO,
     }];
@@ -1148,6 +1150,7 @@ fn measure_lines_with_shading() {
         char_spacing_pt: Pt::ZERO,
         measured_width: pt(40.0),
         measured_height: pt(14.0),
+        ascent: pt(11.0),
         hyperlink_url: None,
         baseline_offset: Pt::ZERO,
     }];


### PR DESCRIPTION
Add space: Pt to BorderDef and parse w:space (default 0pt). Offset paragraph/table border drawing by border.space. Add Fragment.ascent and TextMeasurer::ascent and use ascent to compute text baseline, shading rects, and underline positions. Update defaults and tests.