### PR TITLE
Construct TextMeasurer with FontMgr

### DIFF
--- a/src/render/layout/fragment.rs
+++ b/src/render/layout/fragment.rs
@@ -174,11 +174,13 @@ pub fn collect_fragments_with_fields(
                     None => (base_font_size, Pt::ZERO),
                 };
 
-                let line_height = measurer.line_height(&font_family, base_font_size, bold, italic);
-                let ascent = measurer.ascent(&font_family, base_font_size, bold, italic);
+                let base_font = measurer.font(&font_family, base_font_size, bold, italic);
+                let fm = base_font.metrics();
+                let line_height = fm.line_height;
+                let ascent = fm.ascent;
+                let render_font = measurer.font(&font_family, font_size, bold, italic);
                 for part in split_words_and_spaces(&tr.text) {
-                    let base_width =
-                        measurer.measure_width(part, &font_family, font_size, bold, italic);
+                    let base_width = render_font.measure_width(part);
                     // Character spacing expands each character's advance width
                     let char_count = part.chars().count() as f32;
                     let measured_width = base_width + char_spacing_pt * char_count;
@@ -226,12 +228,18 @@ pub fn collect_fragments_with_fields(
             }
             Inline::Tab => {
                 let default_size = Pt::from(defaults.font_size);
-                let lh = measurer.line_height(&defaults.font_family, default_size, false, false);
+                let lh = measurer
+                    .font(&defaults.font_family, default_size, false, false)
+                    .metrics()
+                    .line_height;
                 fragments.push(Fragment::Tab { line_height: lh });
             }
             Inline::LineBreak => {
                 let default_size = Pt::from(defaults.font_size);
-                let lh = measurer.line_height(&defaults.font_family, default_size, false, false);
+                let lh = measurer
+                    .font(&defaults.font_family, default_size, false, false)
+                    .metrics()
+                    .line_height;
                 fragments.push(Fragment::LineBreak { line_height: lh });
             }
             Inline::Image(_) => {}
@@ -250,11 +258,13 @@ pub fn collect_fragments_with_fields(
                 let bold = rp.bold;
                 let italic = rp.italic;
                 let char_spacing_pt = rp.char_spacing.map(Pt::from).unwrap_or(Pt::ZERO);
-                let w = measurer.measure_width(&text, &font_family, font_size, bold, italic);
+                let f = measurer.font(&font_family, font_size, bold, italic);
+                let w = f.measure_width(&text);
                 let char_count = text.chars().count() as f32;
                 let measured_width = w + char_spacing_pt * char_count;
-                let lh = measurer.line_height(&font_family, font_size, bold, italic);
-                let ascent = measurer.ascent(&font_family, font_size, bold, italic);
+                let fm = f.metrics();
+                let lh = fm.line_height;
+                let ascent = fm.ascent;
                 fragments.push(Fragment::Text {
                     text,
                     font_family,

--- a/src/render/layout/header_footer.rs
+++ b/src/render/layout/header_footer.rs
@@ -15,7 +15,7 @@ pub(super) fn render_headers_footers(
     font_mgr: &skia_safe::FontMgr,
     image_cache: &super::ImageCache,
 ) {
-    let measurer = measurer::TextMeasurer::with_font_mgr(font_mgr.clone());
+    let measurer = measurer::TextMeasurer::new(font_mgr.clone());
     let num_pages = pages.len() as u32;
 
     for (page_idx, page) in pages.iter_mut().enumerate() {

--- a/src/render/layout/measurer.rs
+++ b/src/render/layout/measurer.rs
@@ -1,9 +1,42 @@
-use skia_safe::FontMgr;
+use skia_safe::{Font, FontMgr};
 
 use crate::dimension::Pt;
 use crate::render::fonts;
 
-/// Measures text using Skia font metrics.
+/// A resolved font ready for measurement.
+/// Created once per (family, size, bold, italic) combination; use it for
+/// both metrics and width measurements to avoid redundant font creation.
+pub struct MeasuredFont {
+    font: Font,
+}
+
+/// Font metrics for a specific font configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct FontMetrics {
+    /// Distance from baseline to top of line (always positive).
+    pub ascent: Pt,
+    /// Total line height (ascent + descent + leading).
+    pub line_height: Pt,
+}
+
+impl MeasuredFont {
+    /// Get font metrics (ascent, line height).
+    pub fn metrics(&self) -> FontMetrics {
+        let (_, m) = self.font.metrics();
+        FontMetrics {
+            ascent: Pt::new(-m.ascent),
+            line_height: Pt::new(-m.ascent + m.descent + m.leading),
+        }
+    }
+
+    /// Measure the width of a text string.
+    pub fn measure_width(&self, text: &str) -> Pt {
+        let (width, _) = self.font.measure_str(text, None);
+        Pt::new(width)
+    }
+}
+
+/// Resolves fonts and measures text using Skia.
 /// Requires a shared `FontMgr` — use the same instance as the layout/paint pipeline.
 pub struct TextMeasurer {
     font_mgr: FontMgr,
@@ -14,32 +47,10 @@ impl TextMeasurer {
         Self { font_mgr }
     }
 
-    /// Measure the width of a text string in points.
-    pub fn measure_width(
-        &self,
-        text: &str,
-        font_family: &str,
-        font_size: Pt,
-        bold: bool,
-        italic: bool,
-    ) -> Pt {
+    /// Resolve a font for the given properties. The returned `MeasuredFont`
+    /// can be used for both metrics and width measurements.
+    pub fn font(&self, font_family: &str, font_size: Pt, bold: bool, italic: bool) -> MeasuredFont {
         let font = fonts::make_font(&self.font_mgr, font_family, font_size, bold, italic);
-        let (width, _) = font.measure_str(text, None);
-        Pt::new(width)
-    }
-
-    /// Get the line height (ascent + descent + leading) for a font.
-    pub fn line_height(&self, font_family: &str, font_size: Pt, bold: bool, italic: bool) -> Pt {
-        let font = fonts::make_font(&self.font_mgr, font_family, font_size, bold, italic);
-        let (_, metrics) = font.metrics();
-        Pt::new(-metrics.ascent + metrics.descent + metrics.leading)
-    }
-
-    /// Get the ascent (distance from baseline to top of line) for a font.
-    /// Always positive.
-    pub fn ascent(&self, font_family: &str, font_size: Pt, bold: bool, italic: bool) -> Pt {
-        let font = fonts::make_font(&self.font_mgr, font_family, font_size, bold, italic);
-        let (_, metrics) = font.metrics();
-        Pt::new(-metrics.ascent)
+        MeasuredFont { font }
     }
 }

--- a/src/render/layout/measurer.rs
+++ b/src/render/layout/measurer.rs
@@ -4,31 +4,14 @@ use crate::dimension::Pt;
 use crate::render::fonts;
 
 /// Measures text using Skia font metrics.
+/// Requires a shared `FontMgr` — use the same instance as the layout/paint pipeline.
 pub struct TextMeasurer {
     font_mgr: FontMgr,
 }
 
-impl Default for TextMeasurer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl TextMeasurer {
-    pub fn new() -> Self {
-        Self {
-            font_mgr: FontMgr::new(),
-        }
-    }
-
-    /// Create a measurer sharing an existing FontMgr.
-    pub fn with_font_mgr(font_mgr: FontMgr) -> Self {
+    pub fn new(font_mgr: FontMgr) -> Self {
         Self { font_mgr }
-    }
-
-    /// Get a reference to the underlying FontMgr.
-    pub fn font_mgr(&self) -> &FontMgr {
-        &self.font_mgr
     }
 
     /// Measure the width of a text string in points.

--- a/src/render/layout/mod.rs
+++ b/src/render/layout/mod.rs
@@ -173,7 +173,7 @@ pub fn layout(doc: &Document, font_mgr: &skia_safe::FontMgr) -> Vec<LayoutedPage
     let image_cache = ImageCache::new(&doc.images);
     let mut effective_config = initial_config;
     if let Some(ref header) = doc.default_header {
-        let pre_measurer = measurer::TextMeasurer::with_font_mgr(font_mgr.clone());
+        let pre_measurer = measurer::TextMeasurer::new(font_mgr.clone());
         let (_, header_bottom) = header_footer::layout_header_footer_blocks(
             &header.blocks,
             initial_config.margins.left,
@@ -339,7 +339,7 @@ impl Layouter {
         font_mgr: skia_safe::FontMgr,
         image_cache: ImageCache,
     ) -> Self {
-        let measurer = TextMeasurer::with_font_mgr(font_mgr);
+        let measurer = TextMeasurer::new(font_mgr);
         Self {
             config: *config,
             pages: Vec::new(),

--- a/src/render/layout/paragraph.rs
+++ b/src/render/layout/paragraph.rs
@@ -63,12 +63,11 @@ impl Layouter {
         if para.runs.is_empty() && para.floats.is_empty() {
             let top = self.cursor_y;
             let default_size = Pt::from(self.doc_defaults.font_size);
-            let natural_height = self.measurer.line_height(
-                &self.doc_defaults.font_family,
-                default_size,
-                false,
-                false,
-            );
+            let natural_height = self
+                .measurer
+                .font(&self.doc_defaults.font_family, default_size, false, false)
+                .metrics()
+                .line_height;
             let line_h = resolve_line_height(natural_height, spacing.line_spacing());
             // Paint borders before advancing — top border sits at paragraph start
             self.paint_paragraph_borders(&para.properties.paragraph_borders, top, top + line_h);

--- a/src/render/layout/table.rs
+++ b/src/render/layout/table.rs
@@ -185,12 +185,16 @@ impl Layouter {
 
                             if fragments.is_empty() && p.floats.is_empty() {
                                 let default_size = Pt::from(self.doc_defaults.font_size);
-                                let natural = self.measurer.line_height(
-                                    &self.doc_defaults.font_family,
-                                    default_size,
-                                    false,
-                                    false,
-                                );
+                                let natural = self
+                                    .measurer
+                                    .font(
+                                        &self.doc_defaults.font_family,
+                                        default_size,
+                                        false,
+                                        false,
+                                    )
+                                    .metrics()
+                                    .line_height;
                                 cell_y += resolve_line_height(natural, spacing.line_spacing());
                                 cell_y += spacing.after.map(Pt::from).unwrap_or(Pt::ZERO);
                                 continue;

--- a/tests/api_compat.rs
+++ b/tests/api_compat.rs
@@ -812,8 +812,8 @@ fn layout_function_exists() {
 #[test]
 fn text_measurer_api() {
     use dxpdf::render::layout::TextMeasurer;
-    let m = TextMeasurer::default();
-    let _: &skia_safe::FontMgr = m.font_mgr();
+    let fm = skia_safe::FontMgr::new();
+    let m = TextMeasurer::new(fm);
     let _: dxpdf::dimension::Pt = m.measure_width(
         "hello",
         "Helvetica",
@@ -823,16 +823,6 @@ fn text_measurer_api() {
     );
     let _: dxpdf::dimension::Pt =
         m.line_height("Helvetica", dxpdf::dimension::Pt::new(12.0), false, false);
-
-    // Also constructible via new()
-    let _ = TextMeasurer::new();
-}
-
-#[test]
-fn text_measurer_with_font_mgr() {
-    use dxpdf::render::layout::TextMeasurer;
-    let fm = skia_safe::FontMgr::default();
-    let _ = TextMeasurer::with_font_mgr(fm);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/api_compat.rs
+++ b/tests/api_compat.rs
@@ -814,15 +814,11 @@ fn text_measurer_api() {
     use dxpdf::render::layout::TextMeasurer;
     let fm = skia_safe::FontMgr::new();
     let m = TextMeasurer::new(fm);
-    let _: dxpdf::dimension::Pt = m.measure_width(
-        "hello",
-        "Helvetica",
-        dxpdf::dimension::Pt::new(12.0),
-        false,
-        false,
-    );
-    let _: dxpdf::dimension::Pt =
-        m.line_height("Helvetica", dxpdf::dimension::Pt::new(12.0), false, false);
+    let f = m.font("Helvetica", dxpdf::dimension::Pt::new(12.0), false, false);
+    let _: dxpdf::dimension::Pt = f.measure_width("hello");
+    let fm = f.metrics();
+    let _: dxpdf::dimension::Pt = fm.line_height;
+    let _: dxpdf::dimension::Pt = fm.ascent;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace TextMeasurer::with_font_mgr and the Default impl with a TextMeasurer::new(font_mgr) constructor. Remove the font_mgr() accessor and
update call sites and tests to construct and pass a skia_safe::FontMgr.