### PR TITLE
Handle decimal OOXML measurements, repeated lists, and paragraph layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ dxpdf handles the most common DOCX features found in real-world business documen
 | Category | Features |
 |---|---|
 | **Text formatting** | Bold, italic, underline, highlighting, font size/family/color, character spacing, superscript/subscript, run shading |
-| **Paragraphs** | Alignment (left/center/right), spacing (before/after/line with auto/exact/atLeast), indentation, tab stops, paragraph borders, paragraph shading |
+| **Paragraphs** | Alignment (left/center/right/justify/distribute), spacing (before/after/line with auto/exact/atLeast), indentation, tab stops, paragraph borders, paragraph shading |
 | **Tables** | Column widths, cell margins (3-level cascade), merged cells (gridSpan + vMerge), row heights, borders, cell shading, nested tables |
 | **Images** | Inline images (PNG, JPEG, BMP, WebP), floating/anchored images with alignment and percentage-based positioning |
 | **Styles** | Paragraph and character styles, `basedOn` inheritance, document defaults, theme fonts |
@@ -198,7 +198,7 @@ Each layout element (paragraphs, table cells, headers/footers) goes through thre
 
 ## OOXML Feature Coverage
 
-Validated against ISO 29500 (Office Open XML). **37 features fully implemented, 9 partial, 13 planned.**
+Validated against ISO 29500 (Office Open XML). **42 features fully implemented, 9 partial, 12 planned.**
 
 <details>
 <summary>Full feature matrix (click to expand)</summary>
@@ -225,7 +225,7 @@ Validated against ISO 29500 (Office Open XML). **37 features fully implemented, 
 | Feature | Status |
 |---|---|
 | Alignment (left, center, right) | ✅ |
-| Alignment (justify) | ⚠️ parsed, renders left-aligned |
+| Alignment (justify, distribute) | ✅ |
 | Spacing before/after, line spacing | ✅ auto/exact/atLeast |
 | Indentation (left, right, first-line, hanging) | ✅ |
 | Tab stops (left) | ✅ |
@@ -233,7 +233,9 @@ Validated against ISO 29500 (Office Open XML). **37 features fully implemented, 
 | Tab stops (decimal) | ⚠️ rendered as left-aligned |
 | Paragraph shading | ✅ |
 | Paragraph borders | ✅ with adjacent border merging, `w:space` offset |
-| Keep with next, widow/orphan control | ❌ |
+| Keep with next | ✅ |
+| Keep lines together | ❌ |
+| Widow/orphan control | ❌ |
 
 ### Styles
 
@@ -251,7 +253,7 @@ Validated against ISO 29500 (Office Open XML). **37 features fully implemented, 
 | Cell widths (pct, auto) | ⚠️ fall back to grid |
 | Cell margins (3-level cascade) | ✅ |
 | Merged cells (gridSpan, vMerge) | ✅ |
-| Row heights | ✅ min / ⚠️ exact treated as min |
+| Row heights | ✅ min / ⚠️ exact as min |
 | Table borders (per-cell, per-table) | ✅ |
 | Border styles (single) | ✅ |
 | Border styles (double, dashed, dotted) | ⚠️ render as single |
@@ -286,7 +288,7 @@ Validated against ISO 29500 (Office Open XML). **37 features fully implemented, 
 | Feature | Status |
 |---|---|
 | Default header/footer | ✅ |
-| First page, even/odd, per-section | ❌ |
+| First page, even/odd, per-section | ✅ |
 
 ### Lists
 

--- a/src/docx/parse/body_schema.rs
+++ b/src/docx/parse/body_schema.rs
@@ -22,6 +22,7 @@ use crate::docx::dimension::{Dimension, Twips};
 use crate::docx::parse::primitives::st_enums::{
     StBrClear, StFldCharType, StPTabAlignment, StPTabLeader, StPTabRelativeTo,
 };
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 use crate::docx::parse::properties::schema::paragraph::PPrXml;
 use crate::docx::parse::properties::schema::run::RPrXml;
 use crate::docx::parse::properties::schema::section::SectPrXml;
@@ -493,7 +494,11 @@ pub(crate) struct TblGridXml {
 
 #[derive(Deserialize)]
 pub(crate) struct GridColXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub w: Option<Dimension<Twips>>,
 }
 

--- a/src/docx/parse/drawing/schema/anchor.rs
+++ b/src/docx/parse/drawing/schema/anchor.rs
@@ -16,6 +16,9 @@ use crate::docx::model::{
     AnchorAlignment, AnchorPosition, AnchorProperties, AnchorRelativeFrom, DocProperties,
     GraphicContent, GraphicFrameLocks, Image, ImagePlacement, TextWrap, WrapPolygon, WrapText,
 };
+use crate::docx::parse::primitives::units::{
+    deserialize_nonnegative_dimension, deserialize_optional_nonnegative_dimension,
+};
 
 use super::fill::AttrBool;
 use super::picture::PictureXml;
@@ -26,22 +29,38 @@ use super::shape::WspXml;
 /// `<wp:extent cx=".." cy=".."/>` — positive size in EMU.
 #[derive(Debug, Deserialize)]
 pub struct ExtentXml {
-    #[serde(rename = "@cx")]
+    #[serde(rename = "@cx", deserialize_with = "deserialize_nonnegative_dimension")]
     pub cx: Dimension<Emu>,
-    #[serde(rename = "@cy")]
+    #[serde(rename = "@cy", deserialize_with = "deserialize_nonnegative_dimension")]
     pub cy: Dimension<Emu>,
 }
 
 /// `<wp:effectExtent l=".." t=".." r=".." b=".."/>` — drawing overflow.
 #[derive(Debug, Deserialize)]
 pub struct EffectExtentXml {
-    #[serde(rename = "@l", default)]
+    #[serde(
+        rename = "@l",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub l: Option<Dimension<Emu>>,
-    #[serde(rename = "@t", default)]
+    #[serde(
+        rename = "@t",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub t: Option<Dimension<Emu>>,
-    #[serde(rename = "@r", default)]
+    #[serde(
+        rename = "@r",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub r: Option<Dimension<Emu>>,
-    #[serde(rename = "@b", default)]
+    #[serde(
+        rename = "@b",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub b: Option<Dimension<Emu>>,
 }
 
@@ -163,13 +182,29 @@ impl GraphicXml {
 /// `<wp:inline>` — inline drawing.
 #[derive(Deserialize)]
 pub(crate) struct InlineXml {
-    #[serde(rename = "@distT", default)]
+    #[serde(
+        rename = "@distT",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_t: Option<Dimension<Emu>>,
-    #[serde(rename = "@distB", default)]
+    #[serde(
+        rename = "@distB",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_b: Option<Dimension<Emu>>,
-    #[serde(rename = "@distL", default)]
+    #[serde(
+        rename = "@distL",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_l: Option<Dimension<Emu>>,
-    #[serde(rename = "@distR", default)]
+    #[serde(
+        rename = "@distR",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_r: Option<Dimension<Emu>>,
 
     #[serde(rename = "extent")]
@@ -207,13 +242,29 @@ impl InlineXml {
 
 #[derive(Deserialize)]
 pub(crate) struct AnchorXml {
-    #[serde(rename = "@distT", default)]
+    #[serde(
+        rename = "@distT",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_t: Option<Dimension<Emu>>,
-    #[serde(rename = "@distB", default)]
+    #[serde(
+        rename = "@distB",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_b: Option<Dimension<Emu>>,
-    #[serde(rename = "@distL", default)]
+    #[serde(
+        rename = "@distL",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_l: Option<Dimension<Emu>>,
-    #[serde(rename = "@distR", default)]
+    #[serde(
+        rename = "@distR",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_r: Option<Dimension<Emu>>,
     #[serde(rename = "@simplePos", default)]
     pub simple_pos_attr: Option<AttrBool>,
@@ -361,13 +412,29 @@ impl From<StAnchorAlignment> for AnchorAlignment {
 pub struct WrapSquareXml {
     #[serde(rename = "@wrapText")]
     pub wrap_text: StWrapText,
-    #[serde(rename = "@distT", default)]
+    #[serde(
+        rename = "@distT",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_t: Option<Dimension<Emu>>,
-    #[serde(rename = "@distB", default)]
+    #[serde(
+        rename = "@distB",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_b: Option<Dimension<Emu>>,
-    #[serde(rename = "@distL", default)]
+    #[serde(
+        rename = "@distL",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_l: Option<Dimension<Emu>>,
-    #[serde(rename = "@distR", default)]
+    #[serde(
+        rename = "@distR",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_r: Option<Dimension<Emu>>,
 }
 
@@ -375,9 +442,17 @@ pub struct WrapSquareXml {
 pub struct WrapTightThroughXml {
     #[serde(rename = "@wrapText")]
     pub wrap_text: StWrapText,
-    #[serde(rename = "@distL", default)]
+    #[serde(
+        rename = "@distL",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_l: Option<Dimension<Emu>>,
-    #[serde(rename = "@distR", default)]
+    #[serde(
+        rename = "@distR",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_r: Option<Dimension<Emu>>,
     #[serde(rename = "wrapPolygon", default)]
     pub polygon: Option<WrapPolygonXml>,
@@ -385,9 +460,17 @@ pub struct WrapTightThroughXml {
 
 #[derive(Debug, Deserialize)]
 pub struct WrapTopAndBottomXml {
-    #[serde(rename = "@distT", default)]
+    #[serde(
+        rename = "@distT",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_t: Option<Dimension<Emu>>,
-    #[serde(rename = "@distB", default)]
+    #[serde(
+        rename = "@distB",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub dist_b: Option<Dimension<Emu>>,
 }
 
@@ -570,6 +653,13 @@ fn polygon(p: WrapPolygonXml) -> Option<WrapPolygon> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn negative_decimal_extent_is_rejected() {
+        let parsed: Result<ExtentXml, _> =
+            quick_xml::de::from_str(r#"<extent cx="-1.5" cy="100"/>"#);
+        assert!(parsed.is_err(), "negative drawing extents must be rejected");
+    }
 
     fn parse_inline(xml: &str) -> Image {
         let wrapped = format!(

--- a/src/docx/parse/drawing/schema/anchor.rs
+++ b/src/docx/parse/drawing/schema/anchor.rs
@@ -38,29 +38,13 @@ pub struct ExtentXml {
 /// `<wp:effectExtent l=".." t=".." r=".." b=".."/>` — drawing overflow.
 #[derive(Debug, Deserialize)]
 pub struct EffectExtentXml {
-    #[serde(
-        rename = "@l",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@l", default)]
     pub l: Option<Dimension<Emu>>,
-    #[serde(
-        rename = "@t",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@t", default)]
     pub t: Option<Dimension<Emu>>,
-    #[serde(
-        rename = "@r",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@r", default)]
     pub r: Option<Dimension<Emu>>,
-    #[serde(
-        rename = "@b",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@b", default)]
     pub b: Option<Dimension<Emu>>,
 }
 
@@ -653,6 +637,16 @@ fn polygon(p: WrapPolygonXml) -> Option<WrapPolygon> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn effect_extent_preserves_signed_decimal_values() {
+        let effect: EffectExtentXml =
+            quick_xml::de::from_str(r#"<effectExtent l="-12.0" t="-24" r="36" b="48"/>"#).unwrap();
+        assert_eq!(effect.l.unwrap().raw(), -12);
+        assert_eq!(effect.t.unwrap().raw(), -24);
+        assert_eq!(effect.r.unwrap().raw(), 36);
+        assert_eq!(effect.b.unwrap().raw(), 48);
+    }
 
     #[test]
     fn negative_decimal_extent_is_rejected() {

--- a/src/docx/parse/drawing/schema/effect.rs
+++ b/src/docx/parse/drawing/schema/effect.rs
@@ -16,6 +16,7 @@ use crate::docx::model::{
 
 use super::color::DrawingColorXml;
 use super::fill::{AttrBool, DrawingFillXml, StRectAlignment};
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 
 // ── Top-level effect list ─────────────────────────────────────────────────
 
@@ -49,7 +50,11 @@ pub enum EffectXml {
 
 #[derive(Debug, Deserialize)]
 pub struct BlurXml {
-    #[serde(rename = "@rad", default)]
+    #[serde(
+        rename = "@rad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub rad: Option<Dimension<Emu>>,
     #[serde(rename = "@grow", default)]
     pub grow: Option<AttrBool>,
@@ -57,23 +62,51 @@ pub struct BlurXml {
 
 #[derive(Debug, Deserialize)]
 pub struct SoftEdgeXml {
-    #[serde(rename = "@rad", default)]
+    #[serde(
+        rename = "@rad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub rad: Option<Dimension<Emu>>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct ReflectionXml {
-    #[serde(rename = "@blurRad", default)]
+    #[serde(
+        rename = "@blurRad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub blur_rad: Option<Dimension<Emu>>,
-    #[serde(rename = "@stA", default)]
+    #[serde(
+        rename = "@stA",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub start_alpha: Option<Dimension<ThousandthPercent>>,
-    #[serde(rename = "@stPos", default)]
+    #[serde(
+        rename = "@stPos",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub start_pos: Option<Dimension<ThousandthPercent>>,
-    #[serde(rename = "@endA", default)]
+    #[serde(
+        rename = "@endA",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub end_alpha: Option<Dimension<ThousandthPercent>>,
-    #[serde(rename = "@endPos", default)]
+    #[serde(
+        rename = "@endPos",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub end_pos: Option<Dimension<ThousandthPercent>>,
-    #[serde(rename = "@dist", default)]
+    #[serde(
+        rename = "@dist",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub distance: Option<Dimension<Emu>>,
     #[serde(rename = "@dir", default)]
     pub direction: Option<Dimension<SixtieThousandthDeg>>,
@@ -105,7 +138,11 @@ pub struct FillOverlayXml {
 
 #[derive(Debug, Deserialize)]
 pub struct GlowXml {
-    #[serde(rename = "@rad", default)]
+    #[serde(
+        rename = "@rad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub rad: Option<Dimension<Emu>>,
     #[serde(rename = "$value", default)]
     pub color: Option<DrawingColorXml>,
@@ -113,9 +150,17 @@ pub struct GlowXml {
 
 #[derive(Debug, Deserialize)]
 pub struct InnerShdwXml {
-    #[serde(rename = "@blurRad", default)]
+    #[serde(
+        rename = "@blurRad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub blur_rad: Option<Dimension<Emu>>,
-    #[serde(rename = "@dist", default)]
+    #[serde(
+        rename = "@dist",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub distance: Option<Dimension<Emu>>,
     #[serde(rename = "@dir", default)]
     pub direction: Option<Dimension<SixtieThousandthDeg>>,
@@ -125,9 +170,17 @@ pub struct InnerShdwXml {
 
 #[derive(Debug, Deserialize)]
 pub struct OuterShdwXml {
-    #[serde(rename = "@blurRad", default)]
+    #[serde(
+        rename = "@blurRad",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub blur_rad: Option<Dimension<Emu>>,
-    #[serde(rename = "@dist", default)]
+    #[serde(
+        rename = "@dist",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub distance: Option<Dimension<Emu>>,
     #[serde(rename = "@dir", default)]
     pub direction: Option<Dimension<SixtieThousandthDeg>>,
@@ -151,7 +204,11 @@ pub struct OuterShdwXml {
 pub struct PrstShdwXml {
     #[serde(rename = "@prst")]
     pub prst: StPresetShadowVal,
-    #[serde(rename = "@dist", default)]
+    #[serde(
+        rename = "@dist",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub distance: Option<Dimension<Emu>>,
     #[serde(rename = "@dir", default)]
     pub direction: Option<Dimension<SixtieThousandthDeg>>,

--- a/src/docx/parse/drawing/schema/fill.rs
+++ b/src/docx/parse/drawing/schema/fill.rs
@@ -14,6 +14,7 @@ use crate::docx::model::{
     GradientShadeProperties, GradientStop, PathShadeType, PatternFill, PresetPatternVal,
     RectAlignment, RelativeRect, StretchFill, TileFill, TileFlipMode,
 };
+use crate::docx::parse::primitives::units::deserialize_nonnegative_dimension;
 pub use crate::docx::parse::primitives::AttrBool;
 
 use super::color::DrawingColorXml;
@@ -91,7 +92,10 @@ pub struct GsLstXml {
 
 #[derive(Debug, Deserialize)]
 pub struct GsXml {
-    #[serde(rename = "@pos")]
+    #[serde(
+        rename = "@pos",
+        deserialize_with = "deserialize_nonnegative_dimension"
+    )]
     pub pos: Dimension<ThousandthPercent>,
     #[serde(rename = "$value")]
     pub color: DrawingColorXml,

--- a/src/docx/parse/drawing/schema/geometry.rs
+++ b/src/docx/parse/drawing/schema/geometry.rs
@@ -14,6 +14,7 @@ use crate::docx::model::{
     AdjCoord, AdjPoint, AdjustHandle, ConnectionSite, CustomGeometry, GeomGuide, PathCommand,
     PathDef, PathFillMode, TextRect,
 };
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 
 // ── CustomGeometry ────────────────────────────────────────────────────────
 
@@ -131,9 +132,17 @@ pub struct PathListXml {
 
 #[derive(Debug, Deserialize, Default)]
 pub struct PathXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub w: Option<Dimension<Emu>>,
-    #[serde(rename = "@h", default)]
+    #[serde(
+        rename = "@h",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub h: Option<Dimension<Emu>>,
     #[serde(rename = "@fill", default)]
     pub fill: Option<StPathFillMode>,

--- a/src/docx/parse/drawing/schema/shape.rs
+++ b/src/docx/parse/drawing/schema/shape.rs
@@ -20,6 +20,9 @@ use crate::docx::model::{
     PresetShapeType, ShapeGeometry, ShapeProperties, StyleMatrixRef, TextAnchoringType,
     TextAutoFit, TextVerticalType, TextWrappingType, Transform2D, WordProcessingShape,
 };
+use crate::docx::parse::primitives::units::{
+    deserialize_nonnegative_dimension, deserialize_optional_nonnegative_dimension,
+};
 
 use super::color::DrawingColorXml;
 use super::effect::EffectListXml;
@@ -135,9 +138,9 @@ pub struct OffXml {
 
 #[derive(Debug, Deserialize)]
 pub struct ExtXml {
-    #[serde(rename = "@cx")]
+    #[serde(rename = "@cx", deserialize_with = "deserialize_nonnegative_dimension")]
     pub cx: Dimension<Emu>,
-    #[serde(rename = "@cy")]
+    #[serde(rename = "@cy", deserialize_with = "deserialize_nonnegative_dimension")]
     pub cy: Dimension<Emu>,
 }
 
@@ -399,13 +402,29 @@ pub struct BodyPrXml {
     pub vert: Option<StTextVerticalType>,
     #[serde(rename = "@wrap", default)]
     pub wrap: Option<StTextWrappingType>,
-    #[serde(rename = "@lIns", default)]
+    #[serde(
+        rename = "@lIns",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub l_ins: Option<Dimension<Emu>>,
-    #[serde(rename = "@tIns", default)]
+    #[serde(
+        rename = "@tIns",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub t_ins: Option<Dimension<Emu>>,
-    #[serde(rename = "@rIns", default)]
+    #[serde(
+        rename = "@rIns",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub r_ins: Option<Dimension<Emu>>,
-    #[serde(rename = "@bIns", default)]
+    #[serde(
+        rename = "@bIns",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub b_ins: Option<Dimension<Emu>>,
     #[serde(rename = "@anchor", default)]
     pub anchor: Option<StTextAnchoringType>,

--- a/src/docx/parse/drawing/schema/stroke.rs
+++ b/src/docx/parse/drawing/schema/stroke.rs
@@ -13,13 +13,20 @@ use crate::docx::model::{
     CompoundLine, DashStop, LineCap, LineDash, LineEnd, LineEndSize, LineEndType, LineJoin,
     Outline, PenAlignment, PresetLineDashVal,
 };
+use crate::docx::parse::primitives::units::{
+    deserialize_nonnegative_dimension, deserialize_optional_nonnegative_dimension,
+};
 
 use super::fill::DrawingFillXml;
 
 /// `<a:ln …>` — outline (§20.1.2.2.24 CT_LineProperties).
 #[derive(Debug, Deserialize)]
 pub struct OutlineXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub w: Option<Dimension<Emu>>,
     #[serde(rename = "@cap", default)]
     pub cap: Option<StLineCap>,
@@ -85,15 +92,19 @@ pub struct CustDashXml {
 
 #[derive(Debug, Deserialize)]
 pub struct DsXml {
-    #[serde(rename = "@d")]
+    #[serde(rename = "@d", deserialize_with = "deserialize_nonnegative_dimension")]
     pub d: Dimension<ThousandthPercent>,
-    #[serde(rename = "@sp")]
+    #[serde(rename = "@sp", deserialize_with = "deserialize_nonnegative_dimension")]
     pub sp: Dimension<ThousandthPercent>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct MiterXml {
-    #[serde(rename = "@lim", default)]
+    #[serde(
+        rename = "@lim",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     pub lim: Option<Dimension<ThousandthPercent>>,
 }
 

--- a/src/docx/parse/numbering.rs
+++ b/src/docx/parse/numbering.rs
@@ -178,3 +178,14 @@ fn convert_num(n: NumXml) -> NumberingInstance {
         level_overrides,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numbering_ids_remain_strict_integers() {
+        let xml = br#"<numbering><abstractNum abstractNumId="1.0"/></numbering>"#;
+        assert!(parse_numbering(xml).is_err());
+    }
+}

--- a/src/docx/parse/numbering.rs
+++ b/src/docx/parse/numbering.rs
@@ -25,14 +25,20 @@ pub fn parse_numbering(data: &[u8]) -> Result<NumberingDefinitions> {
 
 #[derive(Deserialize, Default)]
 struct NumberingXml {
-    #[serde(rename = "abstractNum", default)]
-    abstract_nums: Vec<AbstractNumXml>,
-    #[serde(rename = "num", default)]
-    nums: Vec<NumXml>,
-    /// Picture bullets are parsed structurally here (for id resolution)
-    /// but their `<w:pict>` contents are filled in by the pre-pass.
-    #[serde(rename = "numPicBullet", default)]
-    num_pic_bullets: Vec<NumPicBulletXml>,
+    #[serde(rename = "$value", default)]
+    children: Vec<NumberingChildXml>,
+}
+
+#[derive(Deserialize)]
+enum NumberingChildXml {
+    #[serde(rename = "abstractNum")]
+    AbstractNum(AbstractNumXml),
+    #[serde(rename = "num")]
+    Num(NumXml),
+    #[serde(rename = "numPicBullet")]
+    NumPicBullet(Box<NumPicBulletXml>),
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Deserialize)]
@@ -107,27 +113,32 @@ struct ValAttr<T> {
 impl From<NumberingXml> for NumberingDefinitions {
     fn from(x: NumberingXml) -> Self {
         let mut defs = NumberingDefinitions::default();
-        for a in x.abstract_nums {
-            let id = AbstractNumId::new(a.abstract_num_id);
-            defs.abstract_nums.insert(
-                id,
-                AbstractNumbering {
-                    levels: a.levels.into_iter().map(Into::into).collect(),
-                },
-            );
-        }
-        for n in x.nums {
-            defs.numbering_instances
-                .insert(NumId::new(n.num_id), convert_num(n));
-        }
         // Picture bullets may contain a VML `<w:pict>` (e.g., an imagedata
         // reference). Numbering has no body content, so no embeds crossing
         // into body convert — pass an empty ctx.
         let mut ctx = crate::docx::parse::body::ConvertCtx::new();
-        for bullet in x.num_pic_bullets {
-            let id = NumPicBulletId::new(bullet.num_pic_bullet_id);
-            let pict = bullet.pict.map(|p| p.into_model(&mut ctx));
-            defs.pic_bullets.insert(id, NumPicBullet { id, pict });
+        for child in x.children {
+            match child {
+                NumberingChildXml::AbstractNum(a) => {
+                    let id = AbstractNumId::new(a.abstract_num_id);
+                    defs.abstract_nums.insert(
+                        id,
+                        AbstractNumbering {
+                            levels: a.levels.into_iter().map(Into::into).collect(),
+                        },
+                    );
+                }
+                NumberingChildXml::Num(n) => {
+                    defs.numbering_instances
+                        .insert(NumId::new(n.num_id), convert_num(n));
+                }
+                NumberingChildXml::NumPicBullet(bullet) => {
+                    let id = NumPicBulletId::new(bullet.num_pic_bullet_id);
+                    let pict = bullet.pict.map(|p| p.into_model(&mut ctx));
+                    defs.pic_bullets.insert(id, NumPicBullet { id, pict });
+                }
+                NumberingChildXml::Unknown => {}
+            }
         }
         defs
     }
@@ -185,7 +196,42 @@ mod tests {
 
     #[test]
     fn numbering_ids_remain_strict_integers() {
-        let xml = br#"<numbering><abstractNum abstractNumId="1.0"/></numbering>"#;
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1.0"/></w:numbering>"#;
         assert!(parse_numbering(xml).is_err());
+    }
+
+    #[test]
+    fn repeated_abstract_and_concrete_numbering_definitions_are_collected() {
+        let xml = br#"
+          <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:lvlText w:val="A%1"/></w:lvl></w:abstractNum>
+            <w:num w:numId="11"><w:abstractNumId w:val="1"/></w:num>
+            <w:abstractNum w:abstractNumId="2"><w:lvl w:ilvl="0"><w:lvlText w:val="B%1"/></w:lvl></w:abstractNum>
+            <w:num w:numId="12"><w:abstractNumId w:val="2"/></w:num>
+          </w:numbering>"#;
+        let defs = parse_numbering(xml).unwrap();
+        assert_eq!(defs.abstract_nums.len(), 2);
+        assert_eq!(defs.numbering_instances.len(), 2);
+        assert_eq!(
+            defs.numbering_instances[&NumId::new(11)].abstract_num_id,
+            AbstractNumId::new(1)
+        );
+        assert_eq!(
+            defs.numbering_instances[&NumId::new(12)].abstract_num_id,
+            AbstractNumId::new(2)
+        );
+    }
+
+    #[test]
+    fn unknown_numbering_root_children_do_not_discard_known_definitions() {
+        let xml = br#"
+          <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:abstractNum w:abstractNumId="3"/>
+            <w:futureExtension><w:nested w:val="ignored"/></w:futureExtension>
+            <w:num w:numId="13"><w:abstractNumId w:val="3"/></w:num>
+          </w:numbering>"#;
+        let defs = parse_numbering(xml).unwrap();
+        assert!(defs.abstract_nums.contains_key(&AbstractNumId::new(3)));
+        assert!(defs.numbering_instances.contains_key(&NumId::new(13)));
     }
 }

--- a/src/docx/parse/primitives/integer_measure.rs
+++ b/src/docx/parse/primitives/integer_measure.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Deserializer};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IntegerMeasure(i64);
+
+impl IntegerMeasure {
+    pub(crate) fn value(self) -> i64 {
+        self.0
+    }
+
+    pub(crate) fn is_negative(&self) -> bool {
+        self.0 < 0
+    }
+}
+
+impl<'de> Deserialize<'de> for IntegerMeasure {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        parse_integer_measure(&raw)
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn parse_integer_measure(raw: &str) -> Result<i64, &'static str> {
+    if let Ok(value) = raw.parse::<i64>() {
+        return Ok(value);
+    }
+
+    let (negative, unsigned) = match raw.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, raw.strip_prefix('+').unwrap_or(raw)),
+    };
+    let (whole, fraction) = unsigned
+        .split_once('.')
+        .ok_or("expected an integer or decimal measurement")?;
+    if whole.is_empty()
+        || fraction.is_empty()
+        || !whole.bytes().all(|b| b.is_ascii_digit())
+        || !fraction.bytes().all(|b| b.is_ascii_digit())
+    {
+        return Err("invalid decimal measurement");
+    }
+
+    let magnitude = whole
+        .parse::<i128>()
+        .map_err(|_| "measurement is outside the supported range")?;
+    let rounded_magnitude = magnitude
+        .checked_add(i128::from(fraction.as_bytes()[0] >= b'5'))
+        .ok_or("measurement is outside the supported range")?;
+    let signed = if negative {
+        -rounded_magnitude
+    } else {
+        rounded_magnitude
+    };
+    i64::try_from(signed).map_err(|_| "measurement is outside the supported range")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Value {
+        #[serde(rename = "@val")]
+        val: IntegerMeasure,
+    }
+
+    fn parse(raw: &str) -> Result<i64, quick_xml::DeError> {
+        quick_xml::de::from_str::<Value>(&format!(r#"<x val="{raw}"/>"#))
+            .map(|value| value.val.value())
+    }
+
+    #[test]
+    fn accepts_integer_and_decimal_measurements() {
+        assert_eq!(parse("0").unwrap(), 0);
+        assert_eq!(parse("-120").unwrap(), -120);
+        assert_eq!(parse("100.0").unwrap(), 100);
+        assert_eq!(parse("252.00000000000003").unwrap(), 252);
+        assert_eq!(parse("283.46456692913375").unwrap(), 283);
+    }
+
+    #[test]
+    fn rounds_half_away_from_zero() {
+        assert_eq!(parse("1.5").unwrap(), 2);
+        assert_eq!(parse("-1.5").unwrap(), -2);
+        assert_eq!(parse("1.499").unwrap(), 1);
+        assert_eq!(parse("-1.499").unwrap(), -1);
+    }
+
+    #[test]
+    fn rejects_non_decimal_and_out_of_range_values() {
+        for raw in [
+            "",
+            ".5",
+            "1.",
+            "1e2",
+            "NaN",
+            "inf",
+            "abc",
+            "9223372036854775808",
+            "-9223372036854775809",
+        ] {
+            assert!(parse(raw).is_err(), "{raw:?} must be rejected");
+        }
+    }
+}

--- a/src/docx/parse/primitives/mod.rs
+++ b/src/docx/parse/primitives/mod.rs
@@ -5,6 +5,7 @@
 //! (e.g., `Dimension<U>`) but never leak serde into the model layer.
 
 pub mod colors;
+pub(crate) mod integer_measure;
 pub mod st_enums;
 pub mod toggles;
 pub mod units;

--- a/src/docx/parse/primitives/units.rs
+++ b/src/docx/parse/primitives/units.rs
@@ -4,12 +4,46 @@
 
 use serde::{Deserialize, Deserializer};
 
+use super::integer_measure::IntegerMeasure;
 use crate::model::dimension::{Dimension, Unit};
+
+pub(crate) fn deserialize_nonnegative_dimension<'de, D, U>(
+    deserializer: D,
+) -> Result<Dimension<U>, D::Error>
+where
+    D: Deserializer<'de>,
+    U: Unit,
+{
+    let measure = IntegerMeasure::deserialize(deserializer)?;
+    if measure.is_negative() {
+        return Err(serde::de::Error::custom(
+            "negative value is not valid for this OOXML measurement",
+        ));
+    }
+    Ok(Dimension::new(measure.value()))
+}
+
+pub(crate) fn deserialize_optional_nonnegative_dimension<'de, D, U>(
+    deserializer: D,
+) -> Result<Option<Dimension<U>>, D::Error>
+where
+    D: Deserializer<'de>,
+    U: Unit,
+{
+    Option::<IntegerMeasure>::deserialize(deserializer)?.map_or(Ok(None), |measure| {
+        if measure.is_negative() {
+            Err(serde::de::Error::custom(
+                "negative value is not valid for this OOXML measurement",
+            ))
+        } else {
+            Ok(Some(Dimension::new(measure.value())))
+        }
+    })
+}
 
 impl<'de, U: Unit> Deserialize<'de> for Dimension<U> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let raw = i64::deserialize(d)?;
-        Ok(Dimension::new(raw))
+        Ok(Dimension::new(IntegerMeasure::deserialize(d)?.value()))
     }
 }
 

--- a/src/docx/parse/properties/schema/border.rs
+++ b/src/docx/parse/properties/schema/border.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use crate::docx::model::dimension::{Dimension, EighthPoints, Points};
 use crate::docx::model::{Border, Color, ParagraphBorders, TableBorders, TableCellBorders};
 use crate::docx::parse::primitives::st_enums::StBorderType;
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 use crate::docx::parse::primitives::HexColor;
 
 /// A single `<w:top w:val="..." w:sz="..." w:space="..." w:color="..."/>` etc.
@@ -18,9 +19,17 @@ use crate::docx::parse::primitives::HexColor;
 pub(crate) struct BorderXml {
     #[serde(rename = "@val")]
     val: StBorderType,
-    #[serde(rename = "@sz", default)]
+    #[serde(
+        rename = "@sz",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     sz: Option<Dimension<EighthPoints>>,
-    #[serde(rename = "@space", default)]
+    #[serde(
+        rename = "@space",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     space: Option<Dimension<Points>>,
     #[serde(rename = "@color", default)]
     color: Option<HexColor>,

--- a/src/docx/parse/properties/schema/insets.rs
+++ b/src/docx/parse/properties/schema/insets.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 
 use crate::docx::model::dimension::{Dimension, Twips};
 use crate::docx::model::geometry::{EdgeInsets, PartialEdgeInsets};
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 
 #[derive(Clone, Copy, Debug, Default, Deserialize)]
 pub(crate) struct EdgeInsetsTwipsXml {
@@ -23,7 +24,11 @@ pub(crate) struct EdgeInsetsTwipsXml {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 struct SideXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     w: Option<Dimension<Twips>>,
 }
 

--- a/src/docx/parse/properties/schema/measure.rs
+++ b/src/docx/parse/properties/schema/measure.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 use crate::docx::model::dimension::{Dimension, ThousandthPercent};
 use crate::docx::model::TableMeasure;
+use crate::docx::parse::primitives::integer_measure::IntegerMeasure;
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,7 +24,7 @@ enum StTblWidthType {
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct TableMeasureXml {
     #[serde(rename = "@w", default)]
-    w: Option<i64>,
+    w: Option<IntegerMeasure>,
     #[serde(rename = "@type", default = "default_type")]
     ty: StTblWidthType,
 }
@@ -34,13 +35,33 @@ fn default_type() -> StTblWidthType {
 
 impl From<TableMeasureXml> for TableMeasure {
     fn from(x: TableMeasureXml) -> Self {
+        let value = x.w.map(IntegerMeasure::value).unwrap_or(0);
         match x.ty {
             StTblWidthType::Auto => Self::Auto,
             StTblWidthType::Nil => Self::Nil,
-            StTblWidthType::Dxa => Self::Twips(Dimension::new(x.w.unwrap_or(0))),
-            StTblWidthType::Pct => Self::Pct(Dimension::<ThousandthPercent>::new(x.w.unwrap_or(0))),
+            StTblWidthType::Dxa => Self::Twips(Dimension::new(value)),
+            StTblWidthType::Pct => Self::Pct(Dimension::<ThousandthPercent>::new(value)),
         }
     }
+}
+
+pub(crate) fn deserialize_optional_nonnegative_table_measure<'de, D>(
+    deserializer: D,
+) -> Result<Option<TableMeasureXml>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let measure = Option::<TableMeasureXml>::deserialize(deserializer)?;
+    if measure
+        .as_ref()
+        .and_then(|value| value.w.as_ref())
+        .is_some_and(IntegerMeasure::is_negative)
+    {
+        return Err(serde::de::Error::custom(
+            "negative value is not valid for this OOXML table measurement",
+        ));
+    }
+    Ok(measure)
 }
 
 #[cfg(test)]
@@ -83,5 +104,17 @@ mod tests {
     #[test]
     fn missing_type_defaults_to_auto() {
         assert!(matches!(parse(r#"<tblW/>"#), TableMeasure::Auto));
+    }
+
+    #[test]
+    fn decimal_widths_round_to_nearest_integer() {
+        match parse(r#"<tblW w="2500.4" type="dxa"/>"#) {
+            TableMeasure::Twips(d) => assert_eq!(d.raw(), 2500),
+            other => panic!("expected Twips, got {other:?}"),
+        }
+        match parse(r#"<tblW w="2500.5" type="dxa"/>"#) {
+            TableMeasure::Twips(d) => assert_eq!(d.raw(), 2501),
+            other => panic!("expected Twips, got {other:?}"),
+        }
     }
 }

--- a/src/docx/parse/properties/schema/paragraph.rs
+++ b/src/docx/parse/properties/schema/paragraph.rs
@@ -16,6 +16,7 @@ use crate::docx::parse::primitives::st_enums::{
     StAnchor, StFrameWrap, StHeightRule, StJc, StLineSpacingRule, StTextAlignment, StXAlign,
     StYAlign,
 };
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 use crate::docx::parse::primitives::OnOff;
 
 use super::border::ParagraphBordersXml;
@@ -137,9 +138,17 @@ impl From<IndXml> for Indentation {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 struct SpacingXml {
-    #[serde(rename = "@before", default)]
+    #[serde(
+        rename = "@before",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     before: Option<Dimension<Twips>>,
-    #[serde(rename = "@after", default)]
+    #[serde(
+        rename = "@after",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     after: Option<Dimension<Twips>>,
     #[serde(rename = "@line", default)]
     line: Option<Dimension<Twips>>,
@@ -186,13 +195,29 @@ struct FramePrXml {
     drop_cap: Option<StDropCap>,
     #[serde(rename = "@lines", default)]
     lines: Option<u32>,
-    #[serde(rename = "@hSpace", default)]
+    #[serde(
+        rename = "@hSpace",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     h_space: Option<Dimension<Twips>>,
-    #[serde(rename = "@vSpace", default)]
+    #[serde(
+        rename = "@vSpace",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     v_space: Option<Dimension<Twips>>,
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     w: Option<Dimension<Twips>>,
-    #[serde(rename = "@h", default)]
+    #[serde(
+        rename = "@h",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     h: Option<Dimension<Twips>>,
     #[serde(rename = "@hRule", default)]
     h_rule: Option<StHeightRule>,
@@ -377,6 +402,12 @@ mod tests {
         let ind = r.properties.indentation.unwrap();
         assert_eq!(ind.start.unwrap().raw(), 720);
         assert_eq!(ind.end.unwrap().raw(), 360);
+    }
+
+    #[test]
+    fn negative_decimal_indentation_remains_valid() {
+        let r = parse(r#"<pPr><ind start="-1.5"/></pPr>"#);
+        assert_eq!(r.properties.indentation.unwrap().start.unwrap().raw(), -2);
     }
 
     #[test]

--- a/src/docx/parse/properties/schema/run.rs
+++ b/src/docx/parse/properties/schema/run.rs
@@ -7,9 +7,10 @@
 
 use serde::Deserialize;
 
-use crate::docx::model::dimension::{Dimension, HalfPoints, Twips};
+use crate::docx::model::dimension::{Dimension, HalfPoints, Twips, Unit};
 use crate::docx::model::{RunProperties, StrikeStyle, StyleId, TextScale, UnderlineStyle};
 use crate::docx::parse::primitives::st_enums::{StHighlightColor, StUnderline, StVerticalAlignRun};
+use crate::docx::parse::primitives::units::deserialize_nonnegative_dimension;
 use crate::docx::parse::primitives::{HexColor, OnOff};
 
 use super::border::BorderXml;
@@ -35,7 +36,7 @@ pub(crate) struct RPrXml {
     r_fonts: Option<RFontsXml>,
 
     #[serde(rename = "sz", default)]
-    sz: Option<ValAttr<Dimension<HalfPoints>>>,
+    sz: Option<NonNegativeDimensionVal<HalfPoints>>,
     // Complex-script counterparts are intentionally ignored — renderer uses a single size.
     #[serde(rename = "b", default)]
     b: Vec<OnOff>,
@@ -61,7 +62,7 @@ pub(crate) struct RPrXml {
     #[serde(rename = "spacing", default)]
     spacing: Option<ValAttr<Dimension<Twips>>>,
     #[serde(rename = "kern", default)]
-    kern: Option<ValAttr<Dimension<HalfPoints>>>,
+    kern: Option<NonNegativeDimensionVal<HalfPoints>>,
     /// §17.3.2.45 — `<w:w w:val="80"/>`: horizontal character scale in percent.
     #[serde(rename = "w", default)]
     char_scale: Option<ValAttr<u16>>,
@@ -133,6 +134,16 @@ pub(crate) struct ValString {
 pub(crate) struct ValAttr<T> {
     #[serde(rename = "@val")]
     val: T,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(bound(deserialize = "U: Unit"))]
+struct NonNegativeDimensionVal<U: Unit> {
+    #[serde(
+        rename = "@val",
+        deserialize_with = "deserialize_nonnegative_dimension"
+    )]
+    val: Dimension<U>,
 }
 
 impl RPrXml {
@@ -369,6 +380,12 @@ mod tests {
         // Word treats <w:w w:val="0"/> as the default 100%.
         let (rp, _) = parse(r#"<rPr><w val="0"/></rPr>"#);
         assert_eq!(rp.text_scale, Some(TextScale::NORMAL));
+    }
+
+    #[test]
+    fn negative_decimal_font_size_is_rejected() {
+        let parsed: Result<RPrXml, _> = quick_xml::de::from_str(r#"<rPr><sz val="-1.5"/></rPr>"#);
+        assert!(parsed.is_err(), "negative font sizes must be rejected");
     }
 
     #[test]

--- a/src/docx/parse/properties/schema/section.rs
+++ b/src/docx/parse/properties/schema/section.rs
@@ -12,6 +12,7 @@ use crate::docx::model::{
     SectionRevisionIds, SectionType,
 };
 use crate::docx::parse::primitives::st_enums::{StNumberFormat, StPageOrientation, StSectionMark};
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 use crate::docx::parse::primitives::OnOff;
 
 /// `<w:sectPr>` root.
@@ -59,9 +60,17 @@ pub(crate) enum SectChildXml {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct PgSzXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     w: Option<Dimension<Twips>>,
-    #[serde(rename = "@h", default)]
+    #[serde(
+        rename = "@h",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     h: Option<Dimension<Twips>>,
     #[serde(rename = "@orient", default)]
     orient: Option<StPageOrientation>,
@@ -69,19 +78,47 @@ pub(crate) struct PgSzXml {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct PgMarXml {
-    #[serde(rename = "@top", default)]
+    #[serde(
+        rename = "@top",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     top: Option<Dimension<Twips>>,
-    #[serde(rename = "@right", default)]
+    #[serde(
+        rename = "@right",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     right: Option<Dimension<Twips>>,
-    #[serde(rename = "@bottom", default)]
+    #[serde(
+        rename = "@bottom",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     bottom: Option<Dimension<Twips>>,
-    #[serde(rename = "@left", default)]
+    #[serde(
+        rename = "@left",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     left: Option<Dimension<Twips>>,
-    #[serde(rename = "@header", default)]
+    #[serde(
+        rename = "@header",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     header: Option<Dimension<Twips>>,
-    #[serde(rename = "@footer", default)]
+    #[serde(
+        rename = "@footer",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     footer: Option<Dimension<Twips>>,
-    #[serde(rename = "@gutter", default)]
+    #[serde(
+        rename = "@gutter",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     gutter: Option<Dimension<Twips>>,
 }
 
@@ -89,7 +126,11 @@ pub(crate) struct PgMarXml {
 pub(crate) struct ColsXml {
     #[serde(rename = "@num", default)]
     num: Option<u32>,
-    #[serde(rename = "@space", default)]
+    #[serde(
+        rename = "@space",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     space: Option<Dimension<Twips>>,
     #[serde(rename = "@equalWidth", default)]
     equal_width: Option<OnOffFromAttr>,
@@ -101,9 +142,17 @@ use crate::docx::parse::primitives::AttrBool as OnOffFromAttr;
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct ColXml {
-    #[serde(rename = "@w", default)]
+    #[serde(
+        rename = "@w",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     w: Option<Dimension<Twips>>,
-    #[serde(rename = "@space", default)]
+    #[serde(
+        rename = "@space",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     space: Option<Dimension<Twips>>,
 }
 
@@ -111,9 +160,17 @@ pub(crate) struct ColXml {
 pub(crate) struct DocGridXml {
     #[serde(rename = "@type", default)]
     ty: Option<StDocGrid>,
-    #[serde(rename = "@linePitch", default)]
+    #[serde(
+        rename = "@linePitch",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     line_pitch: Option<Dimension<Twips>>,
-    #[serde(rename = "@charSpace", default)]
+    #[serde(
+        rename = "@charSpace",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     char_space: Option<Dimension<FractionPoints>>,
 }
 

--- a/src/docx/parse/properties/schema/section.rs
+++ b/src/docx/parse/properties/schema/section.rs
@@ -78,11 +78,7 @@ pub(crate) struct PgSzXml {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct PgMarXml {
-    #[serde(
-        rename = "@top",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@top", default)]
     top: Option<Dimension<Twips>>,
     #[serde(
         rename = "@right",
@@ -90,11 +86,7 @@ pub(crate) struct PgMarXml {
         deserialize_with = "deserialize_optional_nonnegative_dimension"
     )]
     right: Option<Dimension<Twips>>,
-    #[serde(
-        rename = "@bottom",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@bottom", default)]
     bottom: Option<Dimension<Twips>>,
     #[serde(
         rename = "@left",
@@ -160,17 +152,9 @@ pub(crate) struct ColXml {
 pub(crate) struct DocGridXml {
     #[serde(rename = "@type", default)]
     ty: Option<StDocGrid>,
-    #[serde(
-        rename = "@linePitch",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@linePitch", default)]
     line_pitch: Option<Dimension<Twips>>,
-    #[serde(
-        rename = "@charSpace",
-        default,
-        deserialize_with = "deserialize_optional_nonnegative_dimension"
-    )]
+    #[serde(rename = "@charSpace", default)]
     char_space: Option<Dimension<FractionPoints>>,
 }
 
@@ -402,6 +386,17 @@ mod tests {
     }
 
     #[test]
+    fn page_margins_preserve_signed_vertical_values() {
+        let s = parse(
+            r#"<sectPr><pgMar top="-720.0" right="1800" bottom="-360"
+                 left="1800" header="720" footer="720" gutter="0"/></sectPr>"#,
+        );
+        let pm = s.page_margins.unwrap();
+        assert_eq!(pm.top.unwrap().raw(), -720);
+        assert_eq!(pm.bottom.unwrap().raw(), -360);
+    }
+
+    #[test]
     fn cols_with_child_definitions() {
         let s = parse(
             r#"<sectPr><cols num="2" space="720" equalWidth="false">
@@ -422,6 +417,16 @@ mod tests {
         let g = s.doc_grid.unwrap();
         assert_eq!(g.grid_type, Some(DocGridType::Lines));
         assert_eq!(g.line_pitch.unwrap().raw(), 360);
+    }
+
+    #[test]
+    fn doc_grid_preserves_signed_decimal_values() {
+        let s = parse(
+            r#"<sectPr><docGrid type="linesAndChars" linePitch="-360.0" charSpace="-12"/></sectPr>"#,
+        );
+        let g = s.doc_grid.unwrap();
+        assert_eq!(g.line_pitch.unwrap().raw(), -360);
+        assert_eq!(g.char_space.unwrap().raw(), -12);
     }
 
     #[test]

--- a/src/docx/parse/properties/schema/table.rs
+++ b/src/docx/parse/properties/schema/table.rs
@@ -15,12 +15,13 @@ use crate::docx::parse::primitives::st_enums::{
     StAnchor, StHeightRule, StJc, StTblLayoutType, StTblOverlap, StTextDirection, StVerticalJc,
     StXAlign, StYAlign,
 };
+use crate::docx::parse::primitives::units::deserialize_optional_nonnegative_dimension;
 use crate::docx::parse::primitives::OnOff;
 
 use super::border::{TableBordersXml, TableCellBordersXml};
 use super::cnf_style::CnfStyleXml;
 use super::insets::EdgeInsetsTwipsXml;
-use super::measure::TableMeasureXml;
+use super::measure::{deserialize_optional_nonnegative_table_measure, TableMeasureXml};
 use super::shading::ShdXml;
 
 // ── tblPr ───────────────────────────────────────────────────────────────
@@ -35,13 +36,21 @@ pub(crate) struct TblPrXml {
     tbl_cell_mar: Option<EdgeInsetsTwipsXml>,
     #[serde(rename = "jc", default)]
     jc: Option<ValAttr<StJc>>,
-    #[serde(rename = "tblW", default)]
+    #[serde(
+        rename = "tblW",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+    )]
     tbl_w: Option<TableMeasureXml>,
     #[serde(rename = "tblLayout", default)]
     tbl_layout: Option<TblLayoutXml>,
     #[serde(rename = "tblInd", default)]
     tbl_ind: Option<TableMeasureXml>,
-    #[serde(rename = "tblCellSpacing", default)]
+    #[serde(
+        rename = "tblCellSpacing",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+    )]
     tbl_cell_spacing: Option<TableMeasureXml>,
     #[serde(rename = "tblLook", default)]
     tbl_look: Option<TblLookXml>,
@@ -141,13 +150,29 @@ impl<'de> Deserialize<'de> for TblLookHex {
 /// `<w:tblpPr>` — floating table positioning.
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct TblpPrXml {
-    #[serde(rename = "@leftFromText", default)]
+    #[serde(
+        rename = "@leftFromText",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     left_from_text: Option<crate::docx::model::dimension::Dimension<Twips>>,
-    #[serde(rename = "@rightFromText", default)]
+    #[serde(
+        rename = "@rightFromText",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     right_from_text: Option<crate::docx::model::dimension::Dimension<Twips>>,
-    #[serde(rename = "@topFromText", default)]
+    #[serde(
+        rename = "@topFromText",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     top_from_text: Option<crate::docx::model::dimension::Dimension<Twips>>,
-    #[serde(rename = "@bottomFromText", default)]
+    #[serde(
+        rename = "@bottomFromText",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     bottom_from_text: Option<crate::docx::model::dimension::Dimension<Twips>>,
     #[serde(rename = "@vertAnchor", default)]
     vert_anchor: Option<StAnchor>,
@@ -275,17 +300,29 @@ pub(crate) struct TrPrXml {
     cnf_style: Option<CnfStyleXml>,
     #[serde(rename = "gridBefore", default)]
     grid_before: Option<ValAttr<u32>>,
-    #[serde(rename = "wBefore", default)]
+    #[serde(
+        rename = "wBefore",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+    )]
     w_before: Option<TableMeasureXml>,
     #[serde(rename = "gridAfter", default)]
     grid_after: Option<ValAttr<u32>>,
-    #[serde(rename = "wAfter", default)]
+    #[serde(
+        rename = "wAfter",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+    )]
     w_after: Option<TableMeasureXml>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) struct TrHeightXml {
-    #[serde(rename = "@val", default)]
+    #[serde(
+        rename = "@val",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_dimension"
+    )]
     val: Option<crate::docx::model::dimension::Dimension<Twips>>,
     #[serde(rename = "@hRule", default)]
     rule: Option<StHeightRule>,
@@ -327,7 +364,11 @@ pub(crate) struct TcPrXml {
     tc_borders: Option<TableCellBordersXml>,
     #[serde(rename = "tcMar", default)]
     tc_mar: Option<EdgeInsetsTwipsXml>,
-    #[serde(rename = "tcW", default)]
+    #[serde(
+        rename = "tcW",
+        default,
+        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+    )]
     tc_w: Option<TableMeasureXml>,
     #[serde(rename = "shd", default)]
     shd: Option<ShdXml>,
@@ -435,6 +476,13 @@ mod tests {
             TableMeasure::Pct(d) => assert_eq!(d.raw(), 5000),
             other => panic!("expected Pct, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn negative_decimal_table_width_is_rejected() {
+        let parsed: Result<TblPrXml, _> =
+            quick_xml::de::from_str(r#"<tblPr><tblW w="-1.5" type="dxa"/></tblPr>"#);
+        assert!(parsed.is_err(), "negative table widths must be rejected");
     }
 
     #[test]

--- a/src/docx/parse/settings.rs
+++ b/src/docx/parse/settings.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use crate::docx::dimension::{Dimension, Twips};
 use crate::docx::error::Result;
 use crate::docx::model::{DocumentSettings, RevisionSaveId};
+use crate::docx::parse::primitives::units::deserialize_nonnegative_dimension;
 use crate::docx::parse::primitives::OnOff;
 use crate::docx::parse::serde_xml::from_xml;
 
@@ -35,7 +36,10 @@ struct RsidsXml {
 #[derive(Deserialize)]
 #[serde(bound(deserialize = "U: crate::docx::dimension::Unit"))]
 struct DimensionVal<U: crate::docx::dimension::Unit> {
-    #[serde(rename = "@val")]
+    #[serde(
+        rename = "@val",
+        deserialize_with = "deserialize_nonnegative_dimension"
+    )]
     val: Dimension<U>,
 }
 

--- a/src/render/layout/fragment/text.rs
+++ b/src/render/layout/fragment/text.rs
@@ -101,7 +101,7 @@ fn split_into_words(text: &str) -> Vec<&str> {
             }
             // Hyphen/dash: break AFTER the hyphen (UAX #14).
             // The hyphen stays with the preceding word.
-            '-' | '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' => {
+            '-' | '\u{2010}' | '\u{2012}' | '\u{2013}' | '\u{2014}' => {
                 let end = i + ch.len_utf8();
                 if end > start {
                     words.push(&text[start..end]);
@@ -305,6 +305,11 @@ mod tests {
     #[test]
     fn split_trailing_space() {
         assert_eq!(split_into_words("hello "), vec!["hello "]);
+    }
+
+    #[test]
+    fn non_breaking_hyphen_stays_inside_word() {
+        assert_eq!(split_into_words("ID‑001"), vec!["ID‑001"]);
     }
 
     // ── L1, L2, L4: emoji cluster integration ────────────────────────────

--- a/src/render/layout/header_footer.rs
+++ b/src/render/layout/header_footer.rs
@@ -74,6 +74,101 @@ pub fn select_slot_with_kind<T>(
     set.default.as_ref().map(|t| (HeaderFooterKind::Default, t))
 }
 
+/// Vertical body boundaries for one physical page.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct PageBodyBounds {
+    /// Absolute y coordinate where body layout starts.
+    pub(crate) top: Pt,
+    /// Absolute y coordinate where body layout ends.
+    pub(crate) bottom: Pt,
+}
+
+impl PageBodyBounds {
+    pub(crate) fn height(self) -> Pt {
+        (self.bottom - self.top).max(Pt::ZERO)
+    }
+}
+
+/// Header/footer clearances measured independently for each OOXML slot.
+///
+/// The selected slot is resolved per physical section page using the same
+/// rules as header/footer drawing. An absent selected slot leaves the
+/// configured body margin unchanged rather than falling back to another slot.
+#[derive(Clone, Debug)]
+pub(crate) struct HeaderFooterClearance {
+    page_height: Pt,
+    configured_top: Pt,
+    configured_bottom: Pt,
+    headers: HeaderFooterSet<Pt>,
+    footers: HeaderFooterSet<Pt>,
+    title_pg: bool,
+    even_and_odd: bool,
+    logical_page_base: usize,
+}
+
+impl HeaderFooterClearance {
+    pub(crate) fn new(
+        config: &PageConfig,
+        headers: HeaderFooterSet<Pt>,
+        footers: HeaderFooterSet<Pt>,
+        title_pg: bool,
+        even_and_odd: bool,
+        logical_page_base: usize,
+    ) -> Self {
+        Self {
+            page_height: config.page_size.height,
+            configured_top: config.margins.top,
+            configured_bottom: config.margins.bottom,
+            headers,
+            footers,
+            title_pg,
+            even_and_odd,
+            logical_page_base,
+        }
+    }
+
+    pub(crate) fn uniform(config: &PageConfig) -> Self {
+        Self::new(
+            config,
+            HeaderFooterSet::default(),
+            HeaderFooterSet::default(),
+            false,
+            false,
+            1,
+        )
+    }
+
+    pub(crate) fn for_page(&self, section_page_index: usize) -> PageBodyBounds {
+        let first_in_section = section_page_index == 0;
+        let logical_page_number = self.logical_page_base + section_page_index;
+        let top = select_slot(
+            &self.headers,
+            first_in_section,
+            logical_page_number,
+            self.title_pg,
+            self.even_and_odd,
+        )
+        .copied()
+        .unwrap_or(self.configured_top)
+        .max(self.configured_top);
+        let bottom_margin = select_slot(
+            &self.footers,
+            first_in_section,
+            logical_page_number,
+            self.title_pg,
+            self.even_and_odd,
+        )
+        .copied()
+        .unwrap_or(self.configured_bottom)
+        .max(self.configured_bottom);
+
+        PageBodyBounds {
+            top,
+            bottom: self.page_height - bottom_margin,
+        }
+    }
+}
+
 /// Header and footer slots for a section, plus the spec flags that
 /// drive per-page selection. Selection rules live in [`select_slot`];
 /// the layout step calls it once per page in `render_headers_footers`.
@@ -585,6 +680,116 @@ mod tests {
                 position.y.raw()
             );
         }
+    }
+
+    #[test]
+    fn clearance_selects_first_even_and_default_bounds_per_page() {
+        let config = test_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: Some(Pt::new(90.0)),
+                first: Some(Pt::new(150.0)),
+                even: Some(Pt::new(110.0)),
+            },
+            HeaderFooterSet {
+                default: Some(Pt::new(80.0)),
+                first: Some(Pt::new(130.0)),
+                even: Some(Pt::new(100.0)),
+            },
+            true,
+            true,
+            1,
+        );
+
+        assert_eq!(
+            clearance.for_page(0),
+            PageBodyBounds {
+                top: Pt::new(150.0),
+                bottom: Pt::new(662.0),
+            },
+        );
+        assert_eq!(
+            clearance.for_page(1),
+            PageBodyBounds {
+                top: Pt::new(110.0),
+                bottom: Pt::new(692.0),
+            },
+        );
+        assert_eq!(
+            clearance.for_page(2),
+            PageBodyBounds {
+                top: Pt::new(90.0),
+                bottom: Pt::new(712.0),
+            },
+        );
+    }
+
+    #[test]
+    fn clearance_uses_configured_margins_when_selected_slots_are_missing() {
+        let config = test_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: Some(Pt::new(120.0)),
+                first: None,
+                even: None,
+            },
+            HeaderFooterSet {
+                default: Some(Pt::new(100.0)),
+                first: None,
+                even: None,
+            },
+            true,
+            true,
+            1,
+        );
+
+        assert_eq!(
+            clearance.for_page(0),
+            PageBodyBounds {
+                top: config.margins.top,
+                bottom: config.page_size.height - config.margins.bottom,
+            },
+            "missing first slots must not fall back to default",
+        );
+        assert_eq!(
+            clearance.for_page(1),
+            PageBodyBounds {
+                top: config.margins.top,
+                bottom: config.page_size.height - config.margins.bottom,
+            },
+            "missing even slots must not fall back to default",
+        );
+    }
+
+    #[test]
+    fn clearance_never_reduces_configured_page_margins() {
+        let config = test_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: Some(Pt::new(40.0)),
+                first: None,
+                even: None,
+            },
+            HeaderFooterSet {
+                default: Some(Pt::new(30.0)),
+                first: None,
+                even: None,
+            },
+            false,
+            false,
+            1,
+        );
+
+        assert_eq!(
+            clearance.for_page(0),
+            PageBodyBounds {
+                top: config.margins.top,
+                bottom: config.page_size.height - config.margins.bottom,
+            },
+        );
     }
 
     /// Truth-table for `select_slot` covering ECMA-376 §17.10.6

--- a/src/render/layout/line.rs
+++ b/src/render/layout/line.rs
@@ -146,7 +146,6 @@ pub fn fit_lines_with_first(
                 text.ends_with(' ') || text.ends_with('\t')
                     || text.ends_with('-')
                     || text.ends_with('\u{2010}') // hyphen
-                    || text.ends_with('\u{2011}') // non-breaking hyphen (still a visual break point)
                     || text.ends_with('\u{2013}') // en-dash
                     || text.ends_with('\u{2014}') // em-dash
             }
@@ -287,6 +286,21 @@ mod tests {
         assert_eq!(lines[0].end, 1); // "hello " on first line
         assert_eq!(lines[1].start, 1);
         assert_eq!(lines[1].end, 3); // "world " + "end" on second line
+    }
+
+    #[test]
+    fn non_breaking_hyphen_is_not_a_break_point() {
+        let frags = vec![
+            text_frag("prefix ", 45.0),
+            text_frag("ID‑", 20.0),
+            text_frag("001", 35.0),
+        ];
+        let lines = fit_lines(&frags, Pt::new(70.0));
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].end, 1);
+        assert_eq!(lines[1].start, 1);
+        assert_eq!(lines[1].end, 3);
     }
 
     #[test]

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -117,6 +117,50 @@ pub(super) fn compute_line_placements(
     placements
 }
 
+fn stretchable_gap_after(fragments: &[Fragment], frag_idx: usize, line_end: usize) -> bool {
+    let Fragment::Text { text, .. } = &fragments[frag_idx] else {
+        return false;
+    };
+    text.ends_with(' ')
+        && fragments[frag_idx + 1..line_end]
+            .iter()
+            .any(|fragment| !matches!(fragment, Fragment::Bookmark { .. }))
+}
+
+fn line_has_justification_tab(fragments: &[Fragment], line_start: usize, line_end: usize) -> bool {
+    fragments[line_start..line_end].iter().any(|fragment| {
+        is_tab_like(fragment)
+            || matches!(fragment, Fragment::Text { text, .. } if text.contains('\t'))
+    })
+}
+
+fn justification_extra_after(
+    fragments: &[Fragment],
+    line: &super::super::line::FittedLine,
+    line_idx: usize,
+    line_count: usize,
+    alignment: crate::model::Alignment,
+    line_has_tabs: bool,
+    remaining: Pt,
+) -> Pt {
+    if alignment != crate::model::Alignment::Both
+        || line.has_break
+        || line_idx + 1 == line_count
+        || line_has_tabs
+        || remaining <= Pt::ZERO
+    {
+        return Pt::ZERO;
+    }
+    let gaps = (line.start..line.end)
+        .filter(|&idx| stretchable_gap_after(fragments, idx, line.end))
+        .count();
+    if gaps == 0 {
+        Pt::ZERO
+    } else {
+        remaining / gaps as f32
+    }
+}
+
 /// Emit `DrawCommand`s for all lines in a paragraph, advancing `cursor_y`
 /// by the total line height consumed.
 ///
@@ -179,8 +223,8 @@ pub(super) fn emit_line_commands(
         // horizontal positioning — paragraph alignment does not apply. Absolute
         // position tabs (§17.3.1.30) place content explicitly for the same
         // reason, so they suppress paragraph alignment too.
-        let line_has_tabs = fragments[line.start..line.end].iter().any(is_tab_like);
-        let align_offset = if line_has_tabs {
+        let line_has_tab_placement = fragments[line.start..line.end].iter().any(is_tab_like);
+        let align_offset = if line_has_tab_placement {
             Pt::ZERO
         } else {
             match style.alignment {
@@ -194,6 +238,15 @@ pub(super) fn emit_line_commands(
                 _ => Pt::ZERO,
             }
         };
+        let extra_per_gap = justification_extra_after(
+            fragments,
+            line,
+            line_idx,
+            line_placements.len(),
+            style.alignment,
+            line_has_justification_tab(fragments, line.start, line.end),
+            remaining,
+        );
 
         let x_start = indent + align_offset;
 
@@ -214,6 +267,13 @@ pub(super) fn emit_line_commands(
                     text_offset,
                     ..
                 } => {
+                    let extra_after = if stretchable_gap_after(fragments, frag_idx, line.end) {
+                        extra_per_gap
+                    } else {
+                        Pt::ZERO
+                    };
+                    let rendered_width = *width + extra_after;
+
                     // §17.3.2.32: render run-level shading behind text.
                     // Uses text bounds (ascent+descent), not full line height.
                     if let Some(bg_color) = shading {
@@ -222,7 +282,7 @@ pub(super) fn emit_line_commands(
                             rect: crate::render::geometry::PtRect::from_xywh(
                                 x,
                                 text_top,
-                                *width,
+                                rendered_width,
                                 metrics.height(),
                             ),
                             color: *bg_color,
@@ -235,7 +295,7 @@ pub(super) fn emit_line_commands(
                         let text_top = *cursor_y + line.ascent - metrics.ascent;
                         let bx = x - bdr.space;
                         let by = text_top;
-                        let bw = *width + bdr.space * 2.0;
+                        let bw = rendered_width + bdr.space * 2.0;
                         let bh = metrics.height();
                         let half = bdr.width * 0.5;
                         // Top
@@ -293,7 +353,7 @@ pub(super) fn emit_line_commands(
                         let rect = crate::render::geometry::PtRect::from_xywh(
                             x,
                             *cursor_y,
-                            *width,
+                            rendered_width,
                             line_height,
                         );
                         if url.starts_with("http://")
@@ -323,14 +383,14 @@ pub(super) fn emit_line_commands(
                         commands.push(DrawCommand::Underline {
                             line: crate::render::geometry::PtLineSegment::new(
                                 PtOffset::new(x, underline_y),
-                                PtOffset::new(x + *width, underline_y),
+                                PtOffset::new(x + rendered_width, underline_y),
                             ),
                             color: *color,
                             width: stroke_width,
                         });
                     }
 
-                    x += *width;
+                    x += rendered_width;
                 }
                 Fragment::Image {
                     size,

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -134,6 +134,21 @@ fn line_has_justification_tab(fragments: &[Fragment], line_start: usize, line_en
     })
 }
 
+fn visible_line_width(fragments: &[Fragment], line: &super::super::line::FittedLine) -> Pt {
+    let last_visible = (line.start..line.end)
+        .rev()
+        .find(|&idx| !matches!(fragments[idx], Fragment::Bookmark { .. }));
+    (line.start..line.end)
+        .map(|idx| {
+            if Some(idx) == last_visible {
+                fragments[idx].trimmed_width()
+            } else {
+                fragments[idx].width()
+            }
+        })
+        .sum()
+}
+
 fn justification_extra_after(
     fragments: &[Fragment],
     line: &super::super::line::FittedLine,
@@ -218,7 +233,7 @@ pub(super) fn emit_line_commands(
         } else {
             (content_width - float_reduction - dc_offset).max(Pt::ZERO)
         };
-        let remaining = (line_available - line.width).max(Pt::ZERO);
+        let remaining = (line_available - visible_line_width(fragments, line)).max(Pt::ZERO);
         // §17.3.1.37: when a line contains tab characters, tab stops control
         // horizontal positioning — paragraph alignment does not apply. Absolute
         // position tabs (§17.3.1.30) place content explicitly for the same

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -129,8 +129,13 @@ fn stretchable_gap_after(fragments: &[Fragment], frag_idx: usize, line_end: usiz
 
 fn line_has_justification_tab(fragments: &[Fragment], line_start: usize, line_end: usize) -> bool {
     fragments[line_start..line_end].iter().any(|fragment| {
-        is_tab_like(fragment)
-            || matches!(fragment, Fragment::Text { text, .. } if text.contains('\t'))
+        matches!(
+            fragment,
+            Fragment::Tab {
+                fitting_width: None,
+                ..
+            } | Fragment::PTab { .. }
+        ) || matches!(fragment, Fragment::Text { text, .. } if text.contains('\t'))
     })
 }
 

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -176,6 +176,52 @@ fn justification_extra_after(
     }
 }
 
+fn distribution_unit_count(fragment: &Fragment, terminal: bool) -> usize {
+    match fragment {
+        Fragment::Text { text, .. } => {
+            if terminal {
+                text.trim_end().chars().count()
+            } else {
+                text.chars().count()
+            }
+        }
+        Fragment::Image { .. } | Fragment::Emoji { .. } => 1,
+        _ => 0,
+    }
+}
+
+fn distribution_gap_count_after(fragments: &[Fragment], frag_idx: usize, line_end: usize) -> usize {
+    let has_following_unit = fragments[frag_idx + 1..line_end]
+        .iter()
+        .any(|fragment| distribution_unit_count(fragment, false) > 0);
+    let units = distribution_unit_count(&fragments[frag_idx], !has_following_unit);
+    if has_following_unit {
+        units
+    } else {
+        units.saturating_sub(1)
+    }
+}
+
+fn distribution_extra_per_gap(
+    fragments: &[Fragment],
+    line: &super::super::line::FittedLine,
+    alignment: crate::model::Alignment,
+    line_has_tabs: bool,
+    remaining: Pt,
+) -> Pt {
+    if alignment != crate::model::Alignment::Distribute || line_has_tabs || remaining <= Pt::ZERO {
+        return Pt::ZERO;
+    }
+    let gaps = (line.start..line.end)
+        .map(|idx| distribution_gap_count_after(fragments, idx, line.end))
+        .sum::<usize>();
+    if gaps == 0 {
+        Pt::ZERO
+    } else {
+        remaining / gaps as f32
+    }
+}
+
 /// Emit `DrawCommand`s for all lines in a paragraph, advancing `cursor_y`
 /// by the total line height consumed.
 ///
@@ -262,6 +308,13 @@ pub(super) fn emit_line_commands(
             line_has_justification_tab(fragments, line.start, line.end),
             remaining,
         );
+        let distribution_extra = distribution_extra_per_gap(
+            fragments,
+            line,
+            style.alignment,
+            line_has_justification_tab(fragments, line.start, line.end),
+            remaining,
+        );
 
         let x_start = indent + align_offset;
 
@@ -287,7 +340,9 @@ pub(super) fn emit_line_commands(
                     } else {
                         Pt::ZERO
                     };
-                    let rendered_width = *width + extra_after;
+                    let distributed_width = distribution_extra
+                        * distribution_gap_count_after(fragments, frag_idx, line.end) as f32;
+                    let rendered_width = *width + extra_after + distributed_width;
 
                     // §17.3.2.32: render run-level shading behind text.
                     // Uses text bounds (ascent+descent), not full line height.
@@ -356,7 +411,7 @@ pub(super) fn emit_line_commands(
                         position: PtOffset::new(x + *text_offset, y),
                         text: text.clone(),
                         font_family: font.family.clone(),
-                        char_spacing: font.char_spacing,
+                        char_spacing: font.char_spacing + distribution_extra,
                         font_size: font.size,
                         bold: font.bold,
                         italic: font.italic,
@@ -425,7 +480,9 @@ pub(super) fn emit_line_commands(
                             src_rect: *src_rect,
                         });
                     }
-                    x += size.width;
+                    x += size.width
+                        + distribution_extra
+                            * distribution_gap_count_after(fragments, frag_idx, line.end) as f32;
                 }
                 Fragment::Emoji {
                     text,
@@ -456,7 +513,9 @@ pub(super) fn emit_line_commands(
                         presentation: *presentation,
                         structure: *structure,
                     });
-                    x += *advance;
+                    x += *advance
+                        + distribution_extra
+                            * distribution_gap_count_after(fragments, frag_idx, line.end) as f32;
                 }
                 Fragment::Tab { .. } => {
                     // §17.3.1.37: resolve to the next tab stop.

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -297,13 +297,9 @@ pub fn layout_paragraph(
         line_placements.is_empty(),
     );
 
-    let total_height = constraints
-        .constrain(PtSize::new(constraints.max_width, cursor_y))
-        .height;
-
     ParagraphLayout {
         commands,
-        size: PtSize::new(constraints.max_width, total_height),
+        size: PtSize::new(constraints.max_width, cursor_y),
     }
 }
 

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -834,14 +834,14 @@ mod tests {
             underlined_text_frag("alpha ", 25.0),
             Fragment::Tab {
                 line_height: Pt::new(14.0),
-                fitting_width: Some(Pt::new(5.0)),
+                fitting_width: None,
             },
             text_frag("beta ", 25.0),
             text_frag("gamma", 30.0),
         ];
         let result = layout_paragraph(
             &fragments,
-            &body_constraints(60.0),
+            &body_constraints(70.0),
             &style,
             Pt::new(14.0),
             None,
@@ -856,6 +856,74 @@ mod tests {
             })
             .expect("underlined structured-tab gap");
         assert!((underline.end.x.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_justifies_after_list_label_separator() {
+        let result = layout_paragraph(
+            &[
+                text_frag("1.", 10.0),
+                Fragment::Tab {
+                    line_height: Pt::new(14.0),
+                    fitting_width: Some(Pt::new(5.0)),
+                },
+                text_frag("alpha ", 20.0),
+                text_frag("beta ", 20.0),
+                text_frag("gamma", 30.0),
+            ],
+            &body_constraints(60.0),
+            &ParagraphStyle {
+                alignment: Alignment::Both,
+                tabs: vec![TabStopDef {
+                    position: Pt::new(15.0),
+                    alignment: crate::model::TabAlignment::Left,
+                    leader: crate::model::TabLeader::None,
+                }],
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+
+        let xs = text_xs(&result);
+        assert!(
+            (xs[2] - 40.0).abs() < 0.01,
+            "the first list-item line must justify after its synthetic label tab: {xs:?}",
+        );
+    }
+
+    #[test]
+    fn both_alignment_justifies_after_picture_bullet_separator() {
+        let result = layout_paragraph(
+            &[
+                image_frag(10.0, 10.0),
+                Fragment::Tab {
+                    line_height: Pt::new(14.0),
+                    fitting_width: Some(Pt::new(5.0)),
+                },
+                text_frag("alpha ", 20.0),
+                text_frag("beta ", 20.0),
+                text_frag("gamma", 30.0),
+            ],
+            &body_constraints(60.0),
+            &ParagraphStyle {
+                alignment: Alignment::Both,
+                tabs: vec![TabStopDef {
+                    position: Pt::new(15.0),
+                    alignment: crate::model::TabAlignment::Left,
+                    leader: crate::model::TabLeader::None,
+                }],
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+
+        let xs = text_xs(&result);
+        assert!(
+            (xs[1] - 40.0).abs() < 0.01,
+            "the first picture-bullet line must justify after its synthetic tab: {xs:?}",
+        );
     }
 
     #[test]

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -647,6 +647,121 @@ mod tests {
     }
 
     #[test]
+    fn distribute_alignment_spreads_characters_across_single_line() {
+        let result = layout_paragraph(
+            &[
+                text_frag("AB", 20.0),
+                hyperlink_frag("CD", 20.0, "https://example.invalid/distributed"),
+            ],
+            &body_constraints(60.0),
+            &ParagraphStyle {
+                alignment: Alignment::Distribute,
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+
+        let texts = result
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text {
+                    position,
+                    char_spacing,
+                    ..
+                } => Some((position.x.raw(), char_spacing.raw())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!((texts[0].0 - 0.0).abs() < 0.01);
+        assert!((texts[1].0 - 33.333).abs() < 0.01, "text runs: {texts:?}");
+        assert!((texts[0].1 - 6.667).abs() < 0.01, "text runs: {texts:?}");
+        assert!((texts[1].1 - 6.667).abs() < 0.01, "text runs: {texts:?}");
+
+        let link = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::LinkAnnotation { rect, url }
+                    if url == "https://example.invalid/distributed" =>
+                {
+                    Some(*rect)
+                }
+                _ => None,
+            })
+            .expect("distributed hyperlink");
+        assert!(((link.origin.x + link.size.width).raw() - 60.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn distribute_alignment_adds_to_existing_character_spacing() {
+        let mut first = text_frag("A", 10.0);
+        let mut second = text_frag("B", 10.0);
+        for fragment in [&mut first, &mut second] {
+            if let Fragment::Text { font, .. } = fragment {
+                Rc::make_mut(font).char_spacing = Pt::new(2.0);
+            }
+        }
+        let result = layout_paragraph(
+            &[first, second],
+            &body_constraints(30.0),
+            &ParagraphStyle {
+                alignment: Alignment::Distribute,
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+        let texts = result
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text {
+                    position,
+                    char_spacing,
+                    ..
+                } => Some((position.x.raw(), char_spacing.raw())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!((texts[0].1 - 12.0).abs() < 0.01, "text runs: {texts:?}");
+        assert!((texts[1].0 - 20.0).abs() < 0.01, "text runs: {texts:?}");
+    }
+
+    #[test]
+    fn distribute_alignment_keeps_tab_lines_at_natural_width() {
+        let result = layout_paragraph(
+            &[
+                text_frag("A", 10.0),
+                Fragment::Tab {
+                    line_height: Pt::new(14.0),
+                    fitting_width: None,
+                },
+                text_frag("B", 10.0),
+            ],
+            &body_constraints(60.0),
+            &ParagraphStyle {
+                alignment: Alignment::Distribute,
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+        let spacings = result
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { char_spacing, .. } => Some(*char_spacing),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(spacings.iter().all(|spacing| *spacing == Pt::ZERO));
+    }
+
+    #[test]
     fn both_alignment_keeps_explicit_break_lines_at_natural_width() {
         let style = ParagraphStyle {
             alignment: Alignment::Both,

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -619,6 +619,34 @@ mod tests {
     }
 
     #[test]
+    fn both_alignment_justifies_from_trimmed_line_width() {
+        let mut trailing = text_frag("beta ", 25.0);
+        if let Fragment::Text { trimmed_width, .. } = &mut trailing {
+            *trimmed_width = Pt::new(20.0);
+        }
+        let result = layout_paragraph(
+            &[
+                text_frag("alpha ", 25.0),
+                trailing,
+                text_frag("gamma", 30.0),
+            ],
+            &body_constraints(60.0),
+            &ParagraphStyle {
+                alignment: Alignment::Both,
+                ..Default::default()
+            },
+            Pt::new(14.0),
+            None,
+        );
+
+        let xs = text_xs(&result);
+        assert!(
+            (xs[1] - 40.0).abs() < 0.01,
+            "the visible first line is 45pt wide, so its gap must grow by 15pt: {xs:?}",
+        );
+    }
+
+    #[test]
     fn both_alignment_keeps_explicit_break_lines_at_natural_width() {
         let style = ParagraphStyle {
             alignment: Alignment::Both,

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -345,6 +345,23 @@ mod tests {
         }
     }
 
+    fn hyperlink_frag(text: &str, width: f32, url: &str) -> Fragment {
+        let mut fragment = text_frag(text, width);
+        if let Fragment::Text { hyperlink_url, .. } = &mut fragment {
+            *hyperlink_url = Some(url.to_string());
+        }
+        fragment
+    }
+
+    fn underlined_text_frag(text: &str, width: f32) -> Fragment {
+        let mut fragment = text_frag(text, width);
+        if let Fragment::Text { font, .. } = &mut fragment {
+            Rc::make_mut(font).underline = true;
+            Rc::make_mut(font).underline_thickness = Pt::new(0.5);
+        }
+        fragment
+    }
+
     fn body_constraints(width: f32) -> BoxConstraints {
         BoxConstraints::new(Pt::ZERO, Pt::new(width), Pt::ZERO, Pt::new(1000.0))
     }
@@ -491,6 +508,312 @@ mod tests {
 
         if let DrawCommand::Text { position, .. } = &result.commands[0] {
             assert_eq!(position.x.raw(), 80.0); // 100 - 20
+        }
+    }
+
+    #[test]
+    fn literal_tab_text_preserves_center_and_end_alignment() {
+        let fragments = vec![text_frag("alpha\tbeta", 20.0)];
+        for (alignment, expected_x) in [(Alignment::Center, 20.0), (Alignment::End, 40.0)] {
+            let style = ParagraphStyle {
+                alignment,
+                ..Default::default()
+            };
+            let result = layout_paragraph(
+                &fragments,
+                &body_constraints(60.0),
+                &style,
+                Pt::new(14.0),
+                None,
+            );
+            assert!((text_xs(&result)[0] - expected_x).abs() < 0.01);
+        }
+    }
+
+    #[test]
+    fn structured_tab_zones_include_literal_tab_text() {
+        for (alignment, expected_xs) in [
+            (crate::model::TabAlignment::Right, [45.0, 55.0, 60.0]),
+            (crate::model::TabAlignment::Center, [62.5, 72.5, 77.5]),
+        ] {
+            let style = ParagraphStyle {
+                tabs: vec![TabStopDef {
+                    position: Pt::new(80.0),
+                    alignment,
+                    leader: crate::model::TabLeader::None,
+                }],
+                ..Default::default()
+            };
+            let result = layout_paragraph(
+                &[
+                    Fragment::Tab {
+                        line_height: Pt::new(14.0),
+                        fitting_width: Some(Pt::new(5.0)),
+                    },
+                    text_frag("alpha", 10.0),
+                    text_frag("\t", 5.0),
+                    text_frag("beta", 20.0),
+                ],
+                &body_constraints(100.0),
+                &style,
+                Pt::new(14.0),
+                None,
+            );
+            let xs = text_xs(&result);
+            for (actual, expected) in xs.iter().zip(expected_xs) {
+                assert!((actual - expected).abs() < 0.01, "xs: {xs:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn both_alignment_expands_inter_word_gaps_on_soft_wrapped_lines() {
+        let mut fragments = vec![
+            text_frag("alpha ", 25.0),
+            hyperlink_frag("beta ", 25.0, "https://example.invalid"),
+            text_frag("gamma", 30.0),
+        ];
+        if let Fragment::Text { font, .. } = &mut fragments[0] {
+            Rc::make_mut(font).underline = true;
+            Rc::make_mut(font).underline_thickness = Pt::new(0.5);
+        }
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let result = layout_paragraph(
+            &fragments,
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        let xs = text_xs(&result);
+        assert!(
+            (xs[1] - 35.0).abs() < 0.01,
+            "beta must receive the 10pt gap: {xs:?}"
+        );
+        assert!(
+            (xs[2] - 0.0).abs() < 0.01,
+            "final line must remain unexpanded: {xs:?}"
+        );
+
+        let underline = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Underline { line, .. } => Some(*line),
+                _ => None,
+            })
+            .expect("underlined first gap");
+        assert!((underline.end.x.raw() - 35.0).abs() < 0.01);
+
+        let link_rect = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::LinkAnnotation { rect, url } if url == "https://example.invalid" => {
+                    Some(*rect)
+                }
+                _ => None,
+            })
+            .expect("beta hyperlink annotation");
+        assert!((link_rect.origin.x.raw() - 35.0).abs() < 0.01);
+        assert!((link_rect.size.width.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_keeps_explicit_break_lines_at_natural_width() {
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let fragments = vec![
+            underlined_text_frag("alpha ", 25.0),
+            text_frag("beta", 25.0),
+            Fragment::LineBreak {
+                line_height: Pt::new(14.0),
+            },
+            text_frag("gamma", 30.0),
+        ];
+        let result = layout_paragraph(
+            &fragments,
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        assert!((text_xs(&result)[1] - 25.0).abs() < 0.01);
+        let underline = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Underline { line, .. } => Some(*line),
+                _ => None,
+            })
+            .expect("underlined explicit-break gap");
+        assert!((underline.end.x.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_does_not_expand_nbsp_gaps() {
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let fragments = vec![
+            underlined_text_frag("alpha\u{00a0}", 25.0),
+            text_frag("beta", 25.0),
+            text_frag("gamma", 30.0),
+        ];
+        let result = layout_paragraph(
+            &fragments,
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        assert!((text_xs(&result)[1] - 25.0).abs() < 0.01);
+        let underline = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Underline { line, .. } => Some(*line),
+                _ => None,
+            })
+            .expect("underlined NBSP gap");
+        assert!((underline.end.x.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_keeps_structured_tab_lines_at_natural_width() {
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let fragments = vec![
+            underlined_text_frag("alpha ", 25.0),
+            Fragment::Tab {
+                line_height: Pt::new(14.0),
+                fitting_width: Some(Pt::new(5.0)),
+            },
+            text_frag("beta ", 25.0),
+            text_frag("gamma", 30.0),
+        ];
+        let result = layout_paragraph(
+            &fragments,
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        assert!((text_xs(&result)[1] - 36.0).abs() < 0.01);
+        let underline = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Underline { line, .. } => Some(*line),
+                _ => None,
+            })
+            .expect("underlined structured-tab gap");
+        assert!((underline.end.x.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_keeps_literal_tab_text_lines_at_natural_width() {
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let fragments = vec![
+            underlined_text_frag("alpha ", 25.0),
+            text_frag("\t", 5.0),
+            text_frag("beta ", 25.0),
+            text_frag("gamma", 30.0),
+        ];
+        let result = layout_paragraph(
+            &fragments,
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        assert!((text_xs(&result)[2] - 30.0).abs() < 0.01);
+        let underline = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Underline { line, .. } => Some(*line),
+                _ => None,
+            })
+            .expect("underlined literal-tab gap");
+        assert!((underline.end.x.raw() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn both_alignment_stretches_hyperlink_run_without_changing_text_order() {
+        let style = ParagraphStyle {
+            alignment: Alignment::Both,
+            ..Default::default()
+        };
+        let result = layout_paragraph(
+            &[
+                text_frag("alpha", 10.0),
+                hyperlink_frag("beta ", 25.0, "https://example.invalid/stretched"),
+                text_frag("gamma ", 15.0),
+                text_frag("delta", 30.0),
+            ],
+            &body_constraints(60.0),
+            &style,
+            Pt::new(14.0),
+            None,
+        );
+        assert!((text_xs(&result)[2] - 45.0).abs() < 0.01);
+        let text_runs: Vec<_> = result
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, .. } => Some(text.to_string()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text_runs, ["alpha", "beta ", "gamma ", "delta"]);
+        let link_rect = result
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::LinkAnnotation { rect, url }
+                    if url == "https://example.invalid/stretched" =>
+                {
+                    Some(*rect)
+                }
+                _ => None,
+            })
+            .expect("stretched hyperlink annotation");
+        assert!((link_rect.origin.x.raw() - 10.0).abs() < 0.01);
+        assert!((link_rect.size.width.raw() - 35.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn start_center_and_end_alignment_positions_are_unchanged() {
+        let fragments = vec![text_frag("alpha ", 25.0), text_frag("beta", 25.0)];
+        for (alignment, expected_x) in [
+            (Alignment::Start, 0.0),
+            (Alignment::Center, 5.0),
+            (Alignment::End, 10.0),
+        ] {
+            let style = ParagraphStyle {
+                alignment,
+                ..Default::default()
+            };
+            let result = layout_paragraph(
+                &fragments,
+                &body_constraints(60.0),
+                &style,
+                Pt::new(14.0),
+                None,
+            );
+            assert!((text_xs(&result)[0] - expected_x).abs() < 0.01);
         }
     }
 

--- a/src/render/layout/section/floating_table.rs
+++ b/src/render/layout/section/floating_table.rs
@@ -161,10 +161,10 @@ pub(super) struct FloatingTablePlan {
 /// Row-splitting and slice production are handled by
 /// `layout_table_paginated`; this function only assigns slices to
 /// page slots.
-pub(super) fn plan_floating_table_pages(
+pub(super) fn plan_floating_table_pages_with_page_tops(
     slices: Vec<TableSlice>,
     anchor_y: Pt,
-    continuation_y: Pt,
+    mut page_top_for_index: impl FnMut(usize) -> Pt,
 ) -> FloatingTablePlan {
     let pages = slices
         .into_iter()
@@ -177,7 +177,7 @@ pub(super) fn plan_floating_table_pages(
                 }
             } else {
                 FloatingTablePagePlacement::Continuation {
-                    y_start: continuation_y,
+                    y_start: page_top_for_index(idx),
                     slice,
                 }
             }
@@ -214,7 +214,10 @@ mod tests {
     /// a single `Anchor` at `anchor_y`.
     #[test]
     fn plan_single_slice_is_one_anchor_placement() {
-        let plan = plan_floating_table_pages(vec![slice(50.0)], Pt::new(100.0), Pt::new(40.0));
+        let plan =
+            plan_floating_table_pages_with_page_tops(vec![slice(50.0)], Pt::new(100.0), |_| {
+                Pt::new(40.0)
+            });
         assert_eq!(plan.pages.len(), 1);
         assert!(matches!(
             plan.pages[0],
@@ -227,10 +230,10 @@ mod tests {
     /// at continuation y.
     #[test]
     fn plan_two_slices_anchor_then_continuation() {
-        let plan = plan_floating_table_pages(
+        let plan = plan_floating_table_pages_with_page_tops(
             vec![slice(700.0), slice(100.0)],
             Pt::new(100.0),
-            Pt::new(40.0),
+            |_| Pt::new(40.0),
         );
         assert_eq!(plan.pages.len(), 2);
         assert!(matches!(
@@ -250,10 +253,10 @@ mod tests {
     /// This pins the "no second anchor page" rule.
     #[test]
     fn plan_n_slices_only_first_is_anchor_page() {
-        let plan = plan_floating_table_pages(
+        let plan = plan_floating_table_pages_with_page_tops(
             vec![slice(700.0), slice(700.0), slice(100.0)],
             Pt::new(150.0),
-            Pt::new(40.0),
+            |_| Pt::new(40.0),
         );
         assert_eq!(plan.pages.len(), 3);
         let anchor_count = plan
@@ -269,12 +272,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn continuation_slices_use_each_page_top_boundary() {
+        let plan = plan_floating_table_pages_with_page_tops(
+            vec![slice(50.0), slice(50.0), slice(50.0)],
+            Pt::new(100.0),
+            |page_index| match page_index {
+                1 => Pt::new(40.0),
+                _ => Pt::new(60.0),
+            },
+        );
+
+        assert_eq!(plan.pages[0].y_start(), Pt::new(100.0));
+        assert_eq!(plan.pages[1].y_start(), Pt::new(40.0));
+        assert_eq!(plan.pages[2].y_start(), Pt::new(60.0));
+    }
+
     /// Empty slice list → empty plan. Edge case: never happens via
     /// `layout_table_paginated` (which returns at least one slice for
     /// non-empty input), but guarded for safety.
     #[test]
     fn plan_empty_slices_returns_empty_plan() {
-        let plan = plan_floating_table_pages(Vec::new(), Pt::new(100.0), Pt::new(40.0));
+        let plan =
+            plan_floating_table_pages_with_page_tops(Vec::new(), Pt::new(100.0), |_| Pt::new(40.0));
         assert!(plan.pages.is_empty());
     }
 
@@ -282,10 +302,10 @@ mod tests {
     /// the planner only assigns placement, never modifies the slice.
     #[test]
     fn plan_preserves_slice_size_through_placement() {
-        let plan = plan_floating_table_pages(
+        let plan = plan_floating_table_pages_with_page_tops(
             vec![slice(123.4), slice(56.7)],
             Pt::new(100.0),
-            Pt::new(40.0),
+            |_| Pt::new(40.0),
         );
         assert_eq!(plan.pages[0].slice().size.height.raw(), 123.4);
         assert_eq!(plan.pages[1].slice().size.height.raw(), 56.7);

--- a/src/render/layout/section/helpers.rs
+++ b/src/render/layout/section/helpers.rs
@@ -45,11 +45,10 @@ pub(super) fn render_page_footnotes(
     default_line_height: Pt,
     measure_text: super::super::paragraph::MeasureTextFn<'_>,
     separator_indent: Pt,
+    page_bottom: Pt,
 ) {
     let content_width = config.content_width();
     let constraints = super::super::BoxConstraints::tight_width(content_width, Pt::INFINITY);
-    let page_bottom = config.page_size.height - config.margins.bottom;
-
     // Layout all footnotes to compute total height.
     let mut footnote_layouts = Vec::new();
     let mut total_height = FOOTNOTE_SEPARATOR_GAP; // separator line + gap above first note

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -2,14 +2,16 @@
 
 use super::super::draw_command::{DrawCommand, LayoutedPage};
 use super::super::float;
+use super::super::header_footer::{HeaderFooterClearance, PageBodyBounds};
 use super::super::page::PageConfig;
 use super::super::paragraph::{layout_paragraph, ParagraphBorderStyle, ParagraphStyle};
 use super::super::table::{
-    layout_table, layout_table_paginated, measure_leading_table_group_height, TablePaginationConfig,
+    layout_table, layout_table_paginated_with_page_heights, measure_leading_table_group_height,
+    TablePaginationConfig, TablePaginationHeights,
 };
 use super::super::BoxConstraints;
 use super::floating_table::{
-    plan_floating_table_pages, resolve_floating_anchor, FloatingTableAnchor,
+    plan_floating_table_pages_with_page_tops, resolve_floating_anchor, FloatingTableAnchor,
     FloatingTablePagePlacement,
 };
 use super::helpers::{
@@ -28,11 +30,16 @@ use crate::render::geometry::PtRect;
 /// Bundles the parameters that are constant for the lifetime of a `layout_section` call.
 struct LayoutCtx<'cx> {
     config: &'cx PageConfig,
+    clearance: &'cx HeaderFooterClearance,
     measure_text: super::super::paragraph::MeasureTextFn<'cx>,
     separator_indent: Pt,
     default_line_height: Pt,
-    /// Absolute bottom boundary of the printable area (page height − bottom margin).
-    page_bottom: Pt,
+}
+
+impl LayoutCtx<'_> {
+    fn page_bounds(&self, section_page_index: usize) -> PageBodyBounds {
+        self.clearance.for_page(section_page_index)
+    }
 }
 
 /// All mutable paging state threaded through `layout_section`.
@@ -44,6 +51,10 @@ struct PageLayoutState<'doc> {
     current_page: LayoutedPage,
     /// Current vertical cursor position on the page.
     cursor_y: Pt,
+    /// 0-based physical page index within the current section.
+    page_index: usize,
+    /// Effective top boundary for the selected header slot on this page.
+    page_top: Pt,
     /// §17.6.4: current column index (0-based).
     current_col: usize,
     /// §17.6.4: y at which columns start on the current page.
@@ -81,10 +92,14 @@ struct PageLayoutState<'doc> {
 }
 
 impl<'doc> PageLayoutState<'doc> {
-    fn new(config: &PageConfig, continuation: Option<ContinuationState>, page_bottom: Pt) -> Self {
+    fn new(
+        config: &PageConfig,
+        continuation: Option<ContinuationState>,
+        bounds: PageBodyBounds,
+    ) -> Self {
         let (current_page, cursor_y) = match continuation {
             Some(c) => (c.page, c.cursor_y),
-            None => (LayoutedPage::new(config.page_size), config.margins.top),
+            None => (LayoutedPage::new(config.page_size), bounds.top),
         };
         PageLayoutState {
             pages: Vec::new(),
@@ -92,8 +107,10 @@ impl<'doc> PageLayoutState<'doc> {
             last_para_start_y: cursor_y,
             current_page,
             cursor_y,
+            page_index: 0,
+            page_top: bounds.top,
             current_col: 0,
-            bottom: page_bottom,
+            bottom: bounds.bottom,
             page_footnotes: Vec::new(),
             first_on_section_page: true,
             prev_space_after: Pt::ZERO,
@@ -118,6 +135,7 @@ impl<'doc> PageLayoutState<'doc> {
                 ctx.default_line_height,
                 ctx.measure_text,
                 ctx.separator_indent,
+                ctx.page_bounds(self.page_index).bottom,
             );
             self.page_footnotes.clear();
         }
@@ -131,10 +149,13 @@ impl<'doc> PageLayoutState<'doc> {
             &mut self.current_page,
             LayoutedPage::new(ctx.config.page_size),
         ));
-        self.cursor_y = ctx.config.margins.top;
-        self.column_top = ctx.config.margins.top;
+        self.page_index += 1;
+        let bounds = ctx.page_bounds(self.page_index);
+        self.page_top = bounds.top;
+        self.cursor_y = bounds.top;
+        self.column_top = bounds.top;
         self.current_col = 0;
-        self.bottom = ctx.page_bottom;
+        self.bottom = bounds.bottom;
         self.page_start_block = block_idx;
         self.abs_floats_dirty = true;
         self.page_floats.clear();
@@ -267,23 +288,45 @@ pub fn layout_section(
     default_line_height: Pt,
     continuation: Option<ContinuationState>,
 ) -> Vec<LayoutedPage> {
-    let content_width = config.content_width();
-    let num_cols = config.num_columns();
-    let page_bottom = config.page_size.height - config.margins.bottom;
-
-    let ctx = LayoutCtx {
+    let clearance = HeaderFooterClearance::uniform(config);
+    layout_section_with_clearance(
+        blocks,
         config,
         measure_text,
         separator_indent,
         default_line_height,
-        page_bottom,
+        continuation,
+        &clearance,
+    )
+}
+
+/// Lay out a sequence of blocks using header/footer clearances selected for
+/// each physical page in the section.
+pub(crate) fn layout_section_with_clearance(
+    blocks: &[LayoutBlock],
+    config: &PageConfig,
+    measure_text: super::super::paragraph::MeasureTextFn<'_>,
+    separator_indent: Pt,
+    default_line_height: Pt,
+    continuation: Option<ContinuationState>,
+    clearance: &HeaderFooterClearance,
+) -> Vec<LayoutedPage> {
+    let content_width = config.content_width();
+    let num_cols = config.num_columns();
+
+    let ctx = LayoutCtx {
+        config,
+        clearance,
+        measure_text,
+        separator_indent,
+        default_line_height,
     };
-    let mut state = PageLayoutState::new(config, continuation, page_bottom);
+    let mut state = PageLayoutState::new(config, continuation, clearance.for_page(0));
 
     // Column-aware constraints and x-offset for the current column.
-    let col_constraints = |col: usize| -> BoxConstraints {
+    let col_constraints = |col: usize, page_height: Pt| -> BoxConstraints {
         let col_width = config.columns[col].width;
-        BoxConstraints::new(Pt::ZERO, col_width, Pt::ZERO, config.content_height())
+        BoxConstraints::new(Pt::ZERO, col_width, Pt::ZERO, page_height)
     };
     let col_x = |col: usize| -> Pt { config.margins.left + config.columns[col].x_offset };
 
@@ -292,7 +335,7 @@ pub fn layout_section(
         // forces this block onto a new page.
         if state.pending_page_break {
             state.pending_page_break = false;
-            if state.cursor_y > config.margins.top {
+            if state.cursor_y > state.page_top {
                 state.push_new_page(block_idx, &ctx);
                 state.prev_space_after = Pt::ZERO;
             }
@@ -308,7 +351,7 @@ pub fn layout_section(
                 floating_shapes,
             } => {
                 // §17.3.1.23: force a new page before this paragraph.
-                if *page_break_before && state.cursor_y > config.margins.top {
+                if *page_break_before && state.cursor_y > state.page_top {
                     state.push_new_page(block_idx, &ctx);
                     state.prev_space_after = Pt::ZERO;
                 }
@@ -317,7 +360,10 @@ pub fn layout_section(
                     && starts_keep_next_chain(blocks, block_idx)
                     && state.page_floats.is_empty()
                 {
-                    let constraints = col_constraints(state.current_col);
+                    let constraints = col_constraints(
+                        state.current_col,
+                        (state.bottom - state.page_top).max(Pt::ZERO),
+                    );
                     if let Some(group_height) = measure_keep_next_group(
                         blocks,
                         block_idx,
@@ -338,7 +384,7 @@ pub fn layout_section(
                             }
                             LayoutBlock::Table { .. } => state.cursor_y,
                         };
-                        let full_page_height = ctx.page_bottom - config.margins.top;
+                        let full_page_height = ctx.page_bounds(state.page_index + 1).height();
                         let fresh_page_group_height = group_height
                             - fresh_page_contextual_space_before(
                                 &blocks[block_idx],
@@ -673,7 +719,10 @@ pub fn layout_section(
                                 config.columns[state.current_col].width;
                         }
 
-                        let constraints = col_constraints(state.current_col);
+                        let constraints = col_constraints(
+                            state.current_col,
+                            (state.bottom - state.page_top).max(Pt::ZERO),
+                        );
                         let para = layout_paragraph(
                             chunk,
                             &constraints,
@@ -814,7 +863,10 @@ pub fn layout_section(
                     let table = layout_table(
                         rows,
                         col_widths,
-                        &col_constraints(state.current_col),
+                        &col_constraints(
+                            state.current_col,
+                            (state.bottom - state.page_top).max(Pt::ZERO),
+                        ),
                         ctx.default_line_height,
                         border_config.as_ref(),
                         ctx.measure_text,
@@ -846,7 +898,7 @@ pub fn layout_section(
                     // the anchor. This matches Word's "don't anchor on a
                     // page that's already mostly full" behavior.
                     if state.cursor_y + table.size.height > state.bottom
-                        && state.cursor_y > config.margins.top
+                        && state.cursor_y > state.page_top
                     {
                         state.push_new_page(block_idx, &ctx);
                         state.prev_space_after = Pt::ZERO;
@@ -862,9 +914,7 @@ pub fn layout_section(
                                 crate::model::TableAnchor::Text => {
                                     state.last_para_start_y + fi.y_offset
                                 }
-                                crate::model::TableAnchor::Margin => {
-                                    config.margins.top + fi.y_offset
-                                }
+                                crate::model::TableAnchor::Margin => state.page_top + fi.y_offset,
                                 crate::model::TableAnchor::Page => fi.y_offset,
                             };
                             anchor_y.max(state.cursor_y)
@@ -895,7 +945,7 @@ pub fn layout_section(
                                 state.push_new_page(block_idx, &ctx);
                                 state.prev_space_after = Pt::ZERO;
                                 // Loop: re-resolve on the fresh page (empty
-                                // float list, cursor at margins.top).
+                                // float list, cursor at the selected page top).
                             }
                         }
                     };
@@ -906,22 +956,30 @@ pub fn layout_section(
                     // §17.4.59: paginate at row boundaries when the table
                     // would overflow. First slice gets the anchor page's
                     // remaining height (`bottom - float_y_start`);
-                    // continuation slices get a full content-area height
-                    // (`bottom - margins.top`) since they start at the
-                    // top of subsequent pages.
+                    // continuation slices get the selected body height for
+                    // each subsequent page.
                     let available_first = (state.bottom - float_y_start).max(Pt::ZERO);
-                    let page_height = (state.bottom - config.margins.top).max(Pt::ZERO);
-                    let slices = layout_table_paginated(
+                    let page_height = ctx.page_bounds(state.page_index + 1).height();
+                    let section_page_index = state.page_index;
+                    let slices = layout_table_paginated_with_page_heights(
                         rows,
                         col_widths,
-                        &col_constraints(state.current_col),
+                        &col_constraints(
+                            state.current_col,
+                            (state.bottom - state.page_top).max(Pt::ZERO),
+                        ),
                         ctx.default_line_height,
                         border_config.as_ref(),
                         ctx.measure_text,
-                        &TablePaginationConfig {
-                            available_height: available_first,
-                            page_height,
-                            suppress_first_row_top: false,
+                        TablePaginationHeights {
+                            config: &TablePaginationConfig {
+                                available_height: available_first,
+                                page_height,
+                                suppress_first_row_top: false,
+                            },
+                            page_height_for_slice: |slice_index| {
+                                ctx.page_bounds(section_page_index + slice_index).height()
+                            },
                         },
                     );
 
@@ -929,7 +987,11 @@ pub fn layout_section(
                     // slices flow at the top of subsequent pages. Encoded
                     // by the `Anchor` / `Continuation` enum variants in
                     // the placement plan.
-                    let plan = plan_floating_table_pages(slices, float_y_start, config.margins.top);
+                    let plan = plan_floating_table_pages_with_page_tops(
+                        slices,
+                        float_y_start,
+                        |slice_index| ctx.page_bounds(section_page_index + slice_index).top,
+                    );
 
                     let table_width = table.size.width;
                     for (page_idx, placement) in plan.pages.into_iter().enumerate() {
@@ -996,17 +1058,26 @@ pub fn layout_section(
                 // Non-floating table: paginated row-level splitting.
                 // §17.4.49 / §17.4.1: split at row boundaries, repeat headers.
                 let available = state.bottom - state.cursor_y;
-                let slices = super::super::table::layout_table_paginated(
+                let section_page_index = state.page_index;
+                let slices = layout_table_paginated_with_page_heights(
                     rows,
                     col_widths,
-                    &col_constraints(state.current_col),
+                    &col_constraints(
+                        state.current_col,
+                        (state.bottom - state.page_top).max(Pt::ZERO),
+                    ),
                     ctx.default_line_height,
                     border_config.as_ref(),
                     ctx.measure_text,
-                    &TablePaginationConfig {
-                        available_height: available,
-                        page_height: config.content_height(),
-                        suppress_first_row_top: suppress_top,
+                    TablePaginationHeights {
+                        config: &TablePaginationConfig {
+                            available_height: available,
+                            page_height: ctx.page_bounds(section_page_index + 1).height(),
+                            suppress_first_row_top: suppress_top,
+                        },
+                        page_height_for_slice: |slice_index| {
+                            ctx.page_bounds(section_page_index + slice_index).height()
+                        },
                     },
                 );
 

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -262,14 +262,36 @@ fn fresh_page_contextual_space_before(
     }
 }
 
+struct KeepNextGroupMeasurement {
+    body_height: Pt,
+    footnote_height: Pt,
+    has_footnotes: bool,
+}
+
+impl KeepNextGroupMeasurement {
+    fn total_height(&self, separator_already_reserved: bool) -> Pt {
+        self.body_height
+            + self.footnote_height
+            + if self.has_footnotes && !separator_already_reserved {
+                FOOTNOTE_SEPARATOR_GAP
+            } else {
+                Pt::ZERO
+            }
+    }
+}
+
 fn measure_keep_next_group(
     blocks: &[LayoutBlock],
     start: usize,
     constraints: &BoxConstraints,
     default_line_height: Pt,
     measure_text: super::super::paragraph::MeasureTextFn<'_>,
-) -> Option<Pt> {
-    let mut height = Pt::ZERO;
+) -> Option<KeepNextGroupMeasurement> {
+    let mut measurement = KeepNextGroupMeasurement {
+        body_height: Pt::ZERO,
+        footnote_height: Pt::ZERO,
+        has_footnotes: false,
+    };
     let mut previous_space_after = Pt::ZERO;
     let mut previous_style_id = None;
     let mut index = start;
@@ -280,6 +302,7 @@ fn measure_keep_next_group(
                 fragments,
                 style,
                 page_break_before,
+                footnotes,
                 ..
             } => {
                 if index > start && *page_break_before {
@@ -301,16 +324,27 @@ fn measure_keep_next_group(
                     default_line_height,
                     measure_text,
                 );
-                height += layout.size.height - collapsed;
+                measurement.body_height += layout.size.height - collapsed;
+                for (footnote_fragments, footnote_style) in footnotes {
+                    let footnote = layout_paragraph(
+                        footnote_fragments,
+                        &BoxConstraints::tight_width(constraints.max_width, Pt::INFINITY),
+                        footnote_style,
+                        default_line_height,
+                        measure_text,
+                    );
+                    measurement.footnote_height += footnote.size.height;
+                    measurement.has_footnotes = true;
+                }
                 previous_space_after = effective.space_after;
                 previous_style_id = effective.style_id.clone();
                 if !effective.keep_next {
-                    return Some(height);
+                    return Some(measurement);
                 }
                 index += 1;
             }
             LayoutBlock::Table { .. } => {
-                return Some(height);
+                return Some(measurement);
             }
         }
     }
@@ -405,13 +439,15 @@ pub(crate) fn layout_section_with_clearance(
                         state.current_col,
                         (state.bottom - state.page_top).max(Pt::ZERO),
                     );
-                    if let Some(group_height) = measure_keep_next_group(
+                    if let Some(group) = measure_keep_next_group(
                         blocks,
                         block_idx,
                         &constraints,
                         ctx.default_line_height,
                         ctx.measure_text,
                     ) {
+                        let current_group_height =
+                            group.total_height(!state.page_footnotes.is_empty());
                         let current_group_top = match &blocks[block_idx] {
                             LayoutBlock::Paragraph { style, .. }
                                 if style.contextual_spacing
@@ -426,7 +462,7 @@ pub(crate) fn layout_section_with_clearance(
                             LayoutBlock::Table { .. } => state.cursor_y,
                         };
                         let full_page_height = ctx.page_bounds(state.page_index + 1).height();
-                        let fresh_page_group_height = group_height
+                        let fresh_page_group_height = group.total_height(false)
                             - fresh_page_contextual_space_before(
                                 &blocks[block_idx],
                                 &state.prev_style_id,
@@ -439,7 +475,7 @@ pub(crate) fn layout_section_with_clearance(
                                 ..
                             }) if !rows.is_empty() => {
                                 let current_available =
-                                    state.bottom - current_group_top - group_height;
+                                    state.bottom - current_group_top - current_group_height;
                                 let full_page_available =
                                     full_page_height - fresh_page_group_height;
                                 let leading_group_height = measure_leading_table_group_height(
@@ -456,7 +492,7 @@ pub(crate) fn layout_section_with_clearance(
                             }
                             _ => {
                                 fresh_page_group_height <= full_page_height
-                                    && current_group_top + group_height > state.bottom
+                                    && current_group_top + current_group_height > state.bottom
                             }
                         };
                         if should_move && state.cursor_y > state.column_top {

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -4,7 +4,9 @@ use super::super::draw_command::{DrawCommand, LayoutedPage};
 use super::super::float;
 use super::super::page::PageConfig;
 use super::super::paragraph::{layout_paragraph, ParagraphBorderStyle, ParagraphStyle};
-use super::super::table::{layout_table, layout_table_paginated, TablePaginationConfig};
+use super::super::table::{
+    layout_table, layout_table_paginated, measure_leading_table_group_height, TablePaginationConfig,
+};
 use super::super::BoxConstraints;
 use super::floating_table::{
     plan_floating_table_pages, resolve_floating_anchor, FloatingTableAnchor,
@@ -146,6 +148,113 @@ impl<'doc> PageLayoutState<'doc> {
     }
 }
 
+fn paragraph_keep_next(block: &LayoutBlock) -> bool {
+    matches!(block, LayoutBlock::Paragraph { style, .. } if style.keep_next)
+}
+
+fn starts_keep_next_chain(blocks: &[LayoutBlock], block_idx: usize) -> bool {
+    paragraph_keep_next(&blocks[block_idx])
+        && (block_idx == 0 || !paragraph_keep_next(&blocks[block_idx - 1]))
+}
+
+fn keep_next_terminal_table(blocks: &[LayoutBlock], start: usize) -> Option<&LayoutBlock> {
+    let mut index = start;
+
+    while let Some(block) = blocks.get(index) {
+        match block {
+            LayoutBlock::Paragraph {
+                style,
+                page_break_before,
+                ..
+            } => {
+                if index > start && *page_break_before {
+                    return None;
+                }
+                if !style.keep_next {
+                    return None;
+                }
+                index += 1;
+            }
+            LayoutBlock::Table { .. } => return Some(block),
+        }
+    }
+
+    None
+}
+
+fn fresh_page_contextual_space_before(
+    block: &LayoutBlock,
+    previous_style_id: &Option<StyleId>,
+) -> Pt {
+    let LayoutBlock::Paragraph { style, .. } = block else {
+        return Pt::ZERO;
+    };
+    let effective = style.clone_for_layout();
+    if effective.contextual_spacing
+        && effective.style_id.is_some()
+        && effective.style_id.as_ref() == previous_style_id.as_ref()
+    {
+        effective.space_before
+    } else {
+        Pt::ZERO
+    }
+}
+
+fn measure_keep_next_group(
+    blocks: &[LayoutBlock],
+    start: usize,
+    constraints: &BoxConstraints,
+    default_line_height: Pt,
+    measure_text: super::super::paragraph::MeasureTextFn<'_>,
+) -> Option<Pt> {
+    let mut height = Pt::ZERO;
+    let mut previous_space_after = Pt::ZERO;
+    let mut previous_style_id = None;
+    let mut index = start;
+
+    while let Some(block) = blocks.get(index) {
+        match block {
+            LayoutBlock::Paragraph {
+                fragments,
+                style,
+                page_break_before,
+                ..
+            } => {
+                if index > start && *page_break_before {
+                    return None;
+                }
+                let effective = style.clone_for_layout();
+                let collapsed = if effective.contextual_spacing
+                    && effective.style_id.is_some()
+                    && effective.style_id == previous_style_id
+                {
+                    previous_space_after + effective.space_before
+                } else {
+                    previous_space_after.min(effective.space_before)
+                };
+                let layout = layout_paragraph(
+                    fragments,
+                    constraints,
+                    &effective,
+                    default_line_height,
+                    measure_text,
+                );
+                height += layout.size.height - collapsed;
+                previous_space_after = effective.space_after;
+                previous_style_id = effective.style_id.clone();
+                if !effective.keep_next {
+                    return Some(height);
+                }
+                index += 1;
+            }
+            LayoutBlock::Table { .. } => {
+                return Some(height);
+            }
+        }
+    }
+    None
+}
+
 /// Lay out a sequence of blocks into pages.
 ///
 /// If `continuation` is provided, the section starts on the given page at the
@@ -204,6 +313,72 @@ pub fn layout_section(
                     state.prev_space_after = Pt::ZERO;
                 }
 
+                if num_cols == 1
+                    && starts_keep_next_chain(blocks, block_idx)
+                    && state.page_floats.is_empty()
+                {
+                    let constraints = col_constraints(state.current_col);
+                    if let Some(group_height) = measure_keep_next_group(
+                        blocks,
+                        block_idx,
+                        &constraints,
+                        ctx.default_line_height,
+                        ctx.measure_text,
+                    ) {
+                        let current_group_top = match &blocks[block_idx] {
+                            LayoutBlock::Paragraph { style, .. }
+                                if style.contextual_spacing
+                                    && style.style_id.is_some()
+                                    && style.style_id == state.prev_style_id =>
+                            {
+                                state.cursor_y - state.prev_space_after - style.space_before
+                            }
+                            LayoutBlock::Paragraph { style, .. } => {
+                                state.cursor_y - state.prev_space_after.min(style.space_before)
+                            }
+                            LayoutBlock::Table { .. } => state.cursor_y,
+                        };
+                        let full_page_height = ctx.page_bottom - config.margins.top;
+                        let fresh_page_group_height = group_height
+                            - fresh_page_contextual_space_before(
+                                &blocks[block_idx],
+                                &state.prev_style_id,
+                            );
+                        let should_move = match keep_next_terminal_table(blocks, block_idx) {
+                            Some(LayoutBlock::Table {
+                                rows,
+                                col_widths,
+                                border_config,
+                                ..
+                            }) if !rows.is_empty() => {
+                                let current_available =
+                                    state.bottom - current_group_top - group_height;
+                                let full_page_available =
+                                    full_page_height - fresh_page_group_height;
+                                let leading_group_height = measure_leading_table_group_height(
+                                    rows,
+                                    col_widths,
+                                    ctx.default_line_height,
+                                    border_config.as_ref(),
+                                    ctx.measure_text,
+                                    false,
+                                );
+                                leading_group_height.is_some_and(|height| {
+                                    height <= full_page_available && height > current_available
+                                })
+                            }
+                            _ => {
+                                fresh_page_group_height <= full_page_height
+                                    && current_group_top + group_height > state.bottom
+                            }
+                        };
+                        if should_move && state.cursor_y > state.column_top {
+                            state.push_new_page(block_idx, &ctx);
+                            state.prev_space_after = Pt::ZERO;
+                        }
+                    }
+                }
+
                 let mut effective_style = style.clone_for_layout();
 
                 // Log paragraph info.
@@ -223,9 +398,6 @@ pub fn layout_section(
                     state.cursor_y.raw(), state.current_col,
                     state.page_floats.len(), state.current_page_abs_floats.len()
                 );
-
-                // Save page state for potential keepNext rollback.
-                let cmds_before_para = state.current_page.commands.len();
 
                 // §17.3.1.33: suppress space_before for the structural first
                 // paragraph of a section on its initial page.
@@ -546,69 +718,6 @@ pub fn layout_section(
                 // no non-empty chunk followed, defer the break to the next block.
                 if unresolved_page_break {
                     state.pending_page_break = true;
-                }
-
-                // §17.3.1.14: keepNext — if this paragraph has keep_next, check
-                // whether the next block fits. If not, undo placement and page-break.
-                if effective_style.keep_next
-                    && state.cursor_y > state.column_top
-                    && block_idx + 1 < blocks.len()
-                    && num_cols <= 1
-                // skip for multi-column (too complex)
-                {
-                    let next_fits = match &blocks[block_idx + 1] {
-                        LayoutBlock::Paragraph {
-                            fragments: next_frags,
-                            style: next_style,
-                            ..
-                        } => {
-                            let mut next_eff = next_style.clone_for_layout();
-                            let next_collapse =
-                                effective_style.space_after.min(next_eff.space_before);
-                            let next_cursor = state.cursor_y - next_collapse;
-                            let next_constraints = col_constraints(state.current_col);
-                            next_eff.page_y = next_cursor;
-                            next_eff.page_x = col_x(state.current_col);
-                            next_eff.page_content_width = config.columns[state.current_col].width;
-                            let next_para = layout_paragraph(
-                                next_frags,
-                                &next_constraints,
-                                &next_eff,
-                                ctx.default_line_height,
-                                ctx.measure_text,
-                            );
-                            next_cursor + next_para.size.height <= state.bottom
-                        }
-                        LayoutBlock::Table { .. } => true, // don't keepNext with tables
-                    };
-
-                    if !next_fits {
-                        // Undo this paragraph's commands, then page-break.
-                        state.current_page.commands.truncate(cmds_before_para);
-                        state.push_new_page(block_idx, &ctx);
-
-                        // Re-layout the paragraph on the fresh page.
-                        // keepNext paragraphs at page top retain their space_before.
-                        let constraints = col_constraints(state.current_col);
-                        effective_style.page_y = state.cursor_y;
-                        effective_style.page_x = col_x(state.current_col);
-                        effective_style.page_content_width =
-                            config.columns[state.current_col].width;
-                        effective_style.page_floats = Vec::new();
-                        let para = layout_paragraph(
-                            fragments,
-                            &constraints,
-                            &effective_style,
-                            ctx.default_line_height,
-                            ctx.measure_text,
-                        );
-                        for mut cmd in para.commands {
-                            cmd.shift_y(state.cursor_y);
-                            cmd.shift_x(col_x(state.current_col));
-                            state.current_page.commands.push(cmd);
-                        }
-                        state.cursor_y += para.size.height;
-                    }
                 }
 
                 state.first_on_section_page = false;

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -7,7 +7,7 @@ use super::super::page::PageConfig;
 use super::super::paragraph::{layout_paragraph, ParagraphBorderStyle, ParagraphStyle};
 use super::super::table::{
     layout_table, layout_table_paginated_with_page_heights, measure_leading_table_group_height,
-    TablePaginationConfig, TablePaginationHeights,
+    TablePaginationHeights,
 };
 use super::super::BoxConstraints;
 use super::floating_table::{
@@ -975,7 +975,6 @@ pub(crate) fn layout_section_with_clearance(
                     // continuation slices get the selected body height for
                     // each subsequent page.
                     let available_first = (state.bottom - float_y_start).max(Pt::ZERO);
-                    let page_height = ctx.page_bounds(state.page_index + 1).height();
                     let section_page_index = state.page_index;
                     let slices = layout_table_paginated_with_page_heights(
                         rows,
@@ -988,11 +987,8 @@ pub(crate) fn layout_section_with_clearance(
                         border_config.as_ref(),
                         ctx.measure_text,
                         TablePaginationHeights {
-                            config: &TablePaginationConfig {
-                                available_height: available_first,
-                                page_height,
-                                suppress_first_row_top: false,
-                            },
+                            available_height: available_first,
+                            suppress_first_row_top: false,
                             page_height_for_slice: |slice_index| {
                                 ctx.page_bounds(section_page_index + slice_index).height()
                             },
@@ -1086,11 +1082,8 @@ pub(crate) fn layout_section_with_clearance(
                     border_config.as_ref(),
                     ctx.measure_text,
                     TablePaginationHeights {
-                        config: &TablePaginationConfig {
-                            available_height: available,
-                            page_height: ctx.page_bounds(section_page_index + 1).height(),
-                            suppress_first_row_top: suppress_top,
-                        },
+                        available_height: available,
+                        suppress_first_row_top: suppress_top,
                         page_height_for_slice: |slice_index| {
                             ctx.page_bounds(section_page_index + slice_index).height()
                         },

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -175,7 +175,42 @@ fn paragraph_keep_next(block: &LayoutBlock) -> bool {
 
 fn starts_keep_next_chain(blocks: &[LayoutBlock], block_idx: usize) -> bool {
     paragraph_keep_next(&blocks[block_idx])
-        && (block_idx == 0 || !paragraph_keep_next(&blocks[block_idx - 1]))
+        && (block_idx == 0
+            || matches!(
+                blocks[block_idx],
+                LayoutBlock::Paragraph {
+                    page_break_before: true,
+                    ..
+                }
+            )
+            || !paragraph_keep_next(&blocks[block_idx - 1]))
+}
+
+#[cfg(test)]
+mod keep_next_chain_tests {
+    use super::*;
+    use crate::render::layout::paragraph::ParagraphStyle;
+
+    fn paragraph(keep_next: bool, page_break_before: bool) -> LayoutBlock {
+        LayoutBlock::Paragraph {
+            fragments: Vec::new(),
+            style: ParagraphStyle {
+                keep_next,
+                ..Default::default()
+            },
+            page_break_before,
+            footnotes: Vec::new(),
+            floating_images: Vec::new(),
+            floating_shapes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn page_break_before_starts_a_new_keep_next_chain() {
+        let blocks = [paragraph(true, false), paragraph(true, true)];
+
+        assert!(starts_keep_next_chain(&blocks, 1));
+    }
 }
 
 fn keep_next_terminal_table(blocks: &[LayoutBlock], start: usize) -> Option<&LayoutBlock> {

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -196,7 +196,13 @@ fn keep_next_terminal_table(blocks: &[LayoutBlock], start: usize) -> Option<&Lay
                 }
                 index += 1;
             }
-            LayoutBlock::Table { .. } => return Some(block),
+            LayoutBlock::Table {
+                float_info: None, ..
+            } => return Some(block),
+            LayoutBlock::Table {
+                float_info: Some(_),
+                ..
+            } => return None,
         }
     }
 

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -186,33 +186,6 @@ fn starts_keep_next_chain(blocks: &[LayoutBlock], block_idx: usize) -> bool {
             || !paragraph_keep_next(&blocks[block_idx - 1]))
 }
 
-#[cfg(test)]
-mod keep_next_chain_tests {
-    use super::*;
-    use crate::render::layout::paragraph::ParagraphStyle;
-
-    fn paragraph(keep_next: bool, page_break_before: bool) -> LayoutBlock {
-        LayoutBlock::Paragraph {
-            fragments: Vec::new(),
-            style: ParagraphStyle {
-                keep_next,
-                ..Default::default()
-            },
-            page_break_before,
-            footnotes: Vec::new(),
-            floating_images: Vec::new(),
-            floating_shapes: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn page_break_before_starts_a_new_keep_next_chain() {
-        let blocks = [paragraph(true, false), paragraph(true, true)];
-
-        assert!(starts_keep_next_chain(&blocks, 1));
-    }
-}
-
 fn keep_next_terminal_table(blocks: &[LayoutBlock], start: usize) -> Option<&LayoutBlock> {
     let mut index = start;
 
@@ -1200,4 +1173,31 @@ pub(crate) fn layout_section_with_clearance(
 
     // Flush remaining footnotes and push the last page.
     state.finalize(&ctx)
+}
+
+#[cfg(test)]
+mod keep_next_chain_tests {
+    use super::*;
+    use crate::render::layout::paragraph::ParagraphStyle;
+
+    fn paragraph(keep_next: bool, page_break_before: bool) -> LayoutBlock {
+        LayoutBlock::Paragraph {
+            fragments: Vec::new(),
+            style: ParagraphStyle {
+                keep_next,
+                ..Default::default()
+            },
+            page_break_before,
+            footnotes: Vec::new(),
+            floating_images: Vec::new(),
+            floating_shapes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn page_break_before_starts_a_new_keep_next_chain() {
+        let blocks = [paragraph(true, false), paragraph(true, true)];
+
+        assert!(starts_keep_next_chain(&blocks, 1));
+    }
 }

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -723,7 +723,7 @@ pub(crate) fn layout_section_with_clearance(
                             state.current_col,
                             (state.bottom - state.page_top).max(Pt::ZERO),
                         );
-                        let para = layout_paragraph(
+                        let mut para = layout_paragraph(
                             chunk,
                             &constraints,
                             &effective_style,
@@ -744,6 +744,22 @@ pub(crate) fn layout_section_with_clearance(
                             // Update para_start_y after page/column change so
                             // floating images use the correct position.
                             para_start_y = state.cursor_y;
+                            effective_style.page_y = state.cursor_y;
+                            effective_style.page_x = col_x(state.current_col);
+                            effective_style.page_content_width =
+                                config.columns[state.current_col].width;
+                            effective_style.page_floats = state.page_floats.clone();
+                            let destination_constraints = col_constraints(
+                                state.current_col,
+                                (state.bottom - state.page_top).max(Pt::ZERO),
+                            );
+                            para = layout_paragraph(
+                                chunk,
+                                &destination_constraints,
+                                &effective_style,
+                                ctx.default_line_height,
+                                ctx.measure_text,
+                            );
                         }
 
                         log::debug!(

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -10,6 +10,7 @@ mod stacker;
 mod types;
 
 pub use layout::layout_section;
+pub(crate) use layout::layout_section_with_clearance;
 pub use stacker::{stack_blocks, StackResult};
 pub use types::*;
 
@@ -41,12 +42,14 @@ mod tests {
     use crate::render::layout::draw_command::DrawCommand;
     use crate::render::layout::fragment::Fragment;
     use crate::render::layout::fragment::{FontProps, TextMetrics};
+    use crate::render::layout::header_footer::HeaderFooterClearance;
     use crate::render::layout::page::PageConfig;
     use crate::render::layout::paragraph::ParagraphStyle;
     use crate::render::layout::table::{
         TableBorderConfig, TableBorderLine, TableBorderStyle, TableCellInput, TableRowInput,
     };
     use crate::render::resolve::color::RgbColor;
+    use crate::render::resolve::header_footer::HeaderFooterSet;
     use std::cell::Cell;
     use std::rc::Rc;
     use std::sync::{Mutex, Once};
@@ -276,6 +279,117 @@ mod tests {
 
         assert_eq!(page1_texts.len(), 5, "5 paras fit on page 1 (5*14=70 < 80)");
         assert_eq!(page2_texts.len(), 1, "1 para on page 2");
+    }
+
+    #[test]
+    fn each_page_uses_its_selected_header_and_footer_clearance() {
+        let config = small_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            true,
+            false,
+            1,
+        );
+        let blocks: Vec<_> = (0..5).map(|i| para_block(&format!("p{i}"), 30.0)).collect();
+
+        let pages = layout_section_with_clearance(
+            &blocks,
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+            &clearance,
+        );
+
+        assert_eq!(pages.len(), 2, "page 2 must use the shorter default slots");
+        let page_texts = pages
+            .iter()
+            .map(|page| {
+                page.commands
+                    .iter()
+                    .filter_map(|command| match command {
+                        DrawCommand::Text { text, position, .. } => {
+                            Some((text.to_string(), position.y))
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            page_texts[0].len(),
+            2,
+            "40pt first-page body fits two lines"
+        );
+        assert_eq!(
+            page_texts[1].len(),
+            3,
+            "80pt default-page body fits the remainder"
+        );
+        assert!(
+            page_texts[1][0].1 < page_texts[0][0].1,
+            "page 2 body must start at the shorter default-header boundary",
+        );
+    }
+
+    #[test]
+    fn footnotes_render_from_the_selected_footer_boundary_once() {
+        let config = small_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet::default(),
+            HeaderFooterSet {
+                default: Some(Pt::new(30.0)),
+                first: None,
+                even: None,
+            },
+            false,
+            false,
+            1,
+        );
+        let block = LayoutBlock::Paragraph {
+            fragments: vec![text_frag("body", 30.0, 14.0)],
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![(
+                vec![text_frag("footnote", 30.0, 14.0)],
+                ParagraphStyle::default(),
+            )],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section_with_clearance(
+            &[block],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+            &clearance,
+        );
+        let separator_y = pages[0]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Line { line, .. } => Some(line.start.y),
+                _ => None,
+            })
+            .expect("footnote separator");
+
+        assert_eq!(separator_y, Pt::new(52.0));
     }
 
     #[test]

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -345,6 +345,74 @@ mod tests {
     }
 
     #[test]
+    fn paragraph_moved_to_taller_page_is_relaid_before_following_block() {
+        let config = small_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            true,
+            false,
+            1,
+        );
+        let moved = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("moved-{i} "), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let pages = layout_section_with_clearance(
+            &[para_block("before", 30.0), moved, para_block("after", 30.0)],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+            &clearance,
+        );
+
+        assert_eq!(pages.len(), 2);
+        let moved_last_y = pages[1]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("moved-") => {
+                    Some(position.y.raw())
+                }
+                _ => None,
+            })
+            .max_by(f32::total_cmp)
+            .expect("moved paragraph text");
+        let after_y = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.as_ref() == "after" => {
+                    Some(position.y.raw())
+                }
+                _ => None,
+            })
+            .expect("following paragraph text");
+
+        assert!(
+            after_y > moved_last_y,
+            "following paragraph at {after_y:?} overlaps moved paragraph ending at {moved_last_y:?}",
+        );
+    }
+
+    #[test]
     fn footnotes_render_from_the_selected_footer_boundary_once() {
         let config = small_config();
         let clearance = HeaderFooterClearance::new(

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -713,6 +713,53 @@ mod tests {
     }
 
     #[test]
+    fn keep_next_fit_includes_group_footnotes() {
+        let mut blocks: Vec<_> = (0..3)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.extend([
+            LayoutBlock::Paragraph {
+                fragments: vec![text_frag("heading", 30.0, 14.0)],
+                style: ParagraphStyle {
+                    keep_next: true,
+                    ..Default::default()
+                },
+                page_break_before: false,
+                footnotes: vec![(
+                    vec![text_frag("footnote", 30.0, 14.0)],
+                    ParagraphStyle::default(),
+                )],
+                floating_images: vec![],
+                floating_shapes: vec![],
+            },
+            styled_para_block("body", false, false),
+        ]);
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let heading_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "heading"))
+            .expect("heading text");
+        let body_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "body"))
+            .expect("body text");
+
+        assert_eq!(
+            heading_page, body_page,
+            "footnote height must participate in keep-next fit checks",
+        );
+    }
+
+    #[test]
     fn contextual_keep_next_chain_stays_when_collapsed_spacing_fits() {
         let mut blocks: Vec<_> = (0..2)
             .map(|i| para_block(&format!("fill{i}"), 30.0))

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -851,6 +851,37 @@ mod tests {
     }
 
     #[test]
+    fn keep_next_does_not_move_heading_before_floating_table() {
+        let mut blocks = (0..4)
+            .map(|i| para_block(&format!("filler-{i}"), 30.0))
+            .collect::<Vec<_>>();
+        blocks.push(styled_para_block("heading", true, false));
+        blocks.push(floating_table_with_rows(1, 15.0));
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let heading_page = pages
+            .iter()
+            .position(|page| {
+                page.commands.iter().any(
+                    |command| matches!(command, DrawCommand::Text { text, .. } if text.as_ref() == "heading"),
+                )
+            })
+            .expect("heading text");
+
+        assert_eq!(
+            heading_page, 0,
+            "a floating table must not act as the terminal block of a keep-next chain",
+        );
+    }
+
+    #[test]
     fn keep_next_heading_moves_with_bordered_first_table_row() {
         let mut blocks: Vec<_> = (0..3)
             .map(|i| para_block(&format!("fill{i}"), 30.0))

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -43,9 +43,56 @@ mod tests {
     use crate::render::layout::fragment::{FontProps, TextMetrics};
     use crate::render::layout::page::PageConfig;
     use crate::render::layout::paragraph::ParagraphStyle;
-    use crate::render::layout::table::{TableCellInput, TableRowInput};
+    use crate::render::layout::table::{
+        TableBorderConfig, TableBorderLine, TableBorderStyle, TableCellInput, TableRowInput,
+    };
     use crate::render::resolve::color::RgbColor;
+    use std::cell::Cell;
     use std::rc::Rc;
+    use std::sync::{Mutex, Once};
+
+    struct TableWarningLogger;
+
+    thread_local! {
+        static CAPTURE_TABLE_WARNINGS: Cell<bool> = const { Cell::new(false) };
+    }
+
+    static TABLE_WARNING_LOGGER: TableWarningLogger = TableWarningLogger;
+    static TABLE_WARNING_LOGGER_INIT: Once = Once::new();
+    static TABLE_WARNINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    impl log::Log for TableWarningLogger {
+        fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+            metadata.level() <= log::Level::Warn
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            if self.enabled(record.metadata())
+                && record.target().starts_with("dxpdf::render::layout::table")
+                && CAPTURE_TABLE_WARNINGS.with(Cell::get)
+            {
+                TABLE_WARNINGS
+                    .lock()
+                    .unwrap()
+                    .push(record.args().to_string());
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    fn capture_table_warnings<T>(run: impl FnOnce() -> T) -> (T, Vec<String>) {
+        TABLE_WARNING_LOGGER_INIT.call_once(|| {
+            log::set_logger(&TABLE_WARNING_LOGGER).unwrap();
+            log::set_max_level(log::LevelFilter::Warn);
+        });
+        TABLE_WARNINGS.lock().unwrap().clear();
+        CAPTURE_TABLE_WARNINGS.with(|capture| capture.set(true));
+        let result = run();
+        CAPTURE_TABLE_WARNINGS.with(|capture| capture.set(false));
+        let warnings = std::mem::take(&mut *TABLE_WARNINGS.lock().unwrap());
+        (result, warnings)
+    }
 
     fn text_frag(text: &str, width: f32, height: f32) -> Fragment {
         Fragment::Text {
@@ -85,6 +132,51 @@ mod tests {
             footnotes: vec![],
             floating_images: vec![],
             floating_shapes: vec![],
+        }
+    }
+
+    fn styled_para_block(text: &str, keep_next: bool, page_break_before: bool) -> LayoutBlock {
+        LayoutBlock::Paragraph {
+            fragments: vec![text_frag(text, 30.0, 14.0)],
+            style: ParagraphStyle {
+                keep_next,
+                ..Default::default()
+            },
+            page_break_before,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        }
+    }
+
+    fn one_column_table(rows: &[(&str, bool)]) -> LayoutBlock {
+        LayoutBlock::Table {
+            rows: rows
+                .iter()
+                .map(|(text, header)| TableRowInput {
+                    cells: vec![TableCellInput {
+                        blocks: vec![para_block(text, 30.0)],
+                        margins: PtEdgeInsets::ZERO,
+                        grid_span: 1,
+                        shading: None,
+                        cell_borders: None,
+                        vertical_merge: None,
+                        vertical_align: crate::render::layout::table::CellVAlign::Top,
+                    }],
+                    height_rule: None,
+                    is_header: Some(*header),
+                    cant_split: Some(true),
+                    grid_before: 0,
+                    grid_after: 0,
+                    border_overrides: None,
+                })
+                .collect(),
+            col_widths: vec![Pt::new(100.0)],
+            border_config: None,
+            indent: Pt::ZERO,
+            alignment: None,
+            float_info: None,
+            style_id: None,
         }
     }
 
@@ -411,6 +503,563 @@ mod tests {
                     .collect()
             })
             .collect()
+    }
+
+    #[test]
+    fn keep_next_chain_moves_with_terminal_paragraph() {
+        let mut blocks: Vec<_> = (0..3)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.extend([
+            styled_para_block("heading", true, false),
+            styled_para_block("subheading", true, false),
+            styled_para_block("body", false, false),
+        ]);
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let last = per_page.last().unwrap();
+        assert!(last.iter().any(|text| text == "heading"));
+        assert!(last.iter().any(|text| text == "subheading"));
+        assert!(last.iter().any(|text| text == "body"));
+    }
+
+    #[test]
+    fn contextual_keep_next_chain_stays_when_collapsed_spacing_fits() {
+        let mut blocks: Vec<_> = (0..2)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        let style = ParagraphStyle {
+            keep_next: true,
+            contextual_spacing: true,
+            style_id: Some(crate::model::StyleId::new("contextual")),
+            space_before: Pt::new(10.0),
+            space_after: Pt::new(10.0),
+            ..Default::default()
+        };
+        blocks.extend([
+            LayoutBlock::Paragraph {
+                fragments: vec![text_frag("heading", 30.0, 14.0)],
+                style: style.clone(),
+                page_break_before: false,
+                footnotes: vec![],
+                floating_images: vec![],
+                floating_shapes: vec![],
+            },
+            LayoutBlock::Paragraph {
+                fragments: vec![text_frag("body", 30.0, 14.0)],
+                style: ParagraphStyle {
+                    keep_next: false,
+                    ..style
+                },
+                page_break_before: false,
+                footnotes: vec![],
+                floating_images: vec![],
+                floating_shapes: vec![],
+            },
+        ]);
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 1);
+        let texts = &texts_per_page(&pages)[0];
+        assert!(texts.iter().any(|text| text == "heading"));
+        assert!(texts.iter().any(|text| text == "body"));
+    }
+
+    #[test]
+    fn contextual_predecessor_allows_keep_next_table_chain_on_fresh_page() {
+        let style = ParagraphStyle {
+            keep_next: true,
+            contextual_spacing: true,
+            style_id: Some(crate::model::StyleId::new("contextual")),
+            space_before: Pt::new(20.0),
+            space_after: Pt::ZERO,
+            ..Default::default()
+        };
+        let mut blocks = vec![
+            para_block("fill", 30.0),
+            LayoutBlock::Paragraph {
+                fragments: vec![text_frag("predecessor", 30.0, 14.0)],
+                style: ParagraphStyle {
+                    keep_next: false,
+                    ..style.clone()
+                },
+                page_break_before: false,
+                footnotes: vec![],
+                floating_images: vec![],
+                floating_shapes: vec![],
+            },
+        ];
+        blocks.extend((0..4).map(|index| LayoutBlock::Paragraph {
+            fragments: vec![text_frag(&format!("chain{index}"), 30.0, 14.0)],
+            style: style.clone(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        }));
+        blocks.push(one_column_table(&[("row0", false), ("row1", false)]));
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let heading_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "chain0"))
+            .unwrap();
+        let row0_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "row0"))
+            .unwrap();
+
+        assert_eq!(heading_page, row0_page);
+    }
+
+    #[test]
+    fn keep_next_heading_moves_with_first_table_row() {
+        for header in [false, true] {
+            let mut blocks: Vec<_> = (0..4)
+                .map(|i| para_block(&format!("fill{i}"), 30.0))
+                .collect();
+            blocks.push(styled_para_block("heading", true, false));
+            blocks.push(one_column_table(&[
+                ("row0", header),
+                ("row1", false),
+                ("row2", false),
+            ]));
+            let pages = layout_section(
+                &blocks,
+                &small_config(),
+                None,
+                Pt::ZERO,
+                Pt::new(14.0),
+                None,
+            );
+            let per_page = texts_per_page(&pages);
+            let heading_page = per_page
+                .iter()
+                .position(|p| p.iter().any(|t| t == "heading"))
+                .unwrap();
+            let row_page = per_page
+                .iter()
+                .position(|p| p.iter().any(|t| t == "row0"))
+                .unwrap();
+            assert_eq!(heading_page, row_page);
+        }
+    }
+
+    #[test]
+    fn keep_next_heading_moves_with_bordered_first_table_row() {
+        let mut blocks: Vec<_> = (0..3)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.push(styled_para_block("heading", true, false));
+        let mut table = one_column_table(&[
+            ("row0", false),
+            ("row1", false),
+            ("row2", false),
+            ("row3", false),
+        ]);
+        if let LayoutBlock::Table { border_config, .. } = &mut table {
+            *border_config = Some(TableBorderConfig {
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+                inside_h: Some(TableBorderLine {
+                    width: Pt::new(12.0),
+                    color: RgbColor::BLACK,
+                    style: TableBorderStyle::Single,
+                }),
+                inside_v: None,
+            });
+        }
+        blocks.push(table);
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let heading_page = per_page
+            .iter()
+            .position(|p| p.iter().any(|text| text == "heading"))
+            .unwrap();
+        let row0_page = per_page
+            .iter()
+            .position(|p| p.iter().any(|text| text == "row0"))
+            .unwrap();
+
+        assert_eq!(heading_page, row0_page);
+        assert!(per_page.iter().skip(row0_page + 1).any(|page| page
+            .iter()
+            .any(|text| text == "row1" || text == "row2" || text == "row3")));
+    }
+
+    #[test]
+    fn oversized_splittable_first_table_row_does_not_move_heading() {
+        let mut blocks: Vec<_> = (0..4)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.push(styled_para_block("heading", true, false));
+        blocks.push(LayoutBlock::Table {
+            rows: vec![TableRowInput {
+                cells: vec![TableCellInput {
+                    blocks: vec![LayoutBlock::Paragraph {
+                        fragments: (0..12)
+                            .flat_map(|i| {
+                                [
+                                    text_frag(&format!("row0-{i}"), 30.0, 14.0),
+                                    Fragment::LineBreak {
+                                        line_height: Pt::new(14.0),
+                                    },
+                                ]
+                            })
+                            .collect(),
+                        style: ParagraphStyle::default(),
+                        page_break_before: false,
+                        footnotes: vec![],
+                        floating_images: vec![],
+                        floating_shapes: vec![],
+                    }],
+                    margins: PtEdgeInsets::ZERO,
+                    grid_span: 1,
+                    shading: None,
+                    cell_borders: None,
+                    vertical_merge: None,
+                    vertical_align: crate::render::layout::table::CellVAlign::Top,
+                }],
+                height_rule: None,
+                is_header: None,
+                cant_split: None,
+                grid_before: 0,
+                grid_after: 0,
+                border_overrides: None,
+            }],
+            col_widths: vec![Pt::new(100.0)],
+            border_config: None,
+            indent: Pt::ZERO,
+            alignment: None,
+            float_info: None,
+            style_id: None,
+        });
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let heading_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "heading"))
+            .unwrap();
+        let first_row_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "row0-0"))
+            .unwrap();
+
+        assert!(heading_page < first_row_page);
+        let flattened: Vec<_> = per_page.into_iter().flatten().collect();
+        for index in 0..12 {
+            let needle = format!("row0-{index}");
+            assert_eq!(flattened.iter().filter(|text| *text == &needle).count(), 1);
+        }
+    }
+
+    #[test]
+    fn keep_next_heading_stays_before_oversized_leading_vmerge_group() {
+        let mut blocks: Vec<_> = (0..4)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.push(styled_para_block("heading", true, false));
+        blocks.push(LayoutBlock::Table {
+            rows: vec![
+                TableRowInput {
+                    cells: vec![
+                        TableCellInput {
+                            blocks: (0..6)
+                                .map(|i| para_block(&format!("restart-{i}"), 30.0))
+                                .collect(),
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: Some(
+                                crate::render::layout::table::VerticalMergeState::Restart,
+                            ),
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                        TableCellInput {
+                            blocks: vec![para_block("row0-peer", 30.0)],
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: None,
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                    ],
+                    height_rule: None,
+                    is_header: None,
+                    cant_split: None,
+                    grid_before: 0,
+                    grid_after: 0,
+                    border_overrides: None,
+                },
+                TableRowInput {
+                    cells: vec![
+                        TableCellInput {
+                            blocks: vec![],
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: Some(
+                                crate::render::layout::table::VerticalMergeState::Continue,
+                            ),
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                        TableCellInput {
+                            blocks: (0..2)
+                                .map(|i| para_block(&format!("continuation-{i}"), 30.0))
+                                .collect(),
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: None,
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                    ],
+                    height_rule: None,
+                    is_header: None,
+                    cant_split: None,
+                    grid_before: 0,
+                    grid_after: 0,
+                    border_overrides: None,
+                },
+                TableRowInput {
+                    cells: vec![
+                        TableCellInput {
+                            blocks: vec![para_block("after-merged", 30.0)],
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: None,
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                        TableCellInput {
+                            blocks: vec![para_block("after-peer", 30.0)],
+                            margins: PtEdgeInsets::ZERO,
+                            grid_span: 1,
+                            shading: None,
+                            cell_borders: None,
+                            vertical_merge: None,
+                            vertical_align: crate::render::layout::table::CellVAlign::Top,
+                        },
+                    ],
+                    height_rule: None,
+                    is_header: None,
+                    cant_split: None,
+                    grid_before: 0,
+                    grid_after: 0,
+                    border_overrides: None,
+                },
+            ],
+            col_widths: vec![Pt::new(50.0), Pt::new(50.0)],
+            border_config: None,
+            indent: Pt::ZERO,
+            alignment: None,
+            float_info: None,
+            style_id: None,
+        });
+
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        let heading_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "heading"))
+            .unwrap();
+        let restart_page = per_page
+            .iter()
+            .position(|page| page.iter().any(|text| text == "restart-0"))
+            .unwrap();
+
+        assert_eq!(heading_page, 0);
+        assert!(heading_page < restart_page);
+        let flattened: Vec<_> = per_page.into_iter().flatten().collect();
+        for text in [
+            "restart-0",
+            "restart-1",
+            "restart-2",
+            "restart-3",
+            "restart-4",
+            "restart-5",
+            "row0-peer",
+            "continuation-0",
+            "continuation-1",
+            "after-merged",
+            "after-peer",
+        ] {
+            assert_eq!(
+                flattened
+                    .iter()
+                    .filter(|candidate| *candidate == text)
+                    .count(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn large_table_keep_next_preflight_does_not_probe_later_groups() {
+        let mut blocks: Vec<_> = (0..4)
+            .map(|i| para_block(&format!("fill{i}"), 30.0))
+            .collect();
+        blocks.push(styled_para_block("heading", true, false));
+        blocks.push(LayoutBlock::Table {
+            rows: (0..24)
+                .map(|i| row_with_label(&format!("row{i}")))
+                .collect(),
+            col_widths: vec![Pt::new(100.0)],
+            border_config: None,
+            indent: Pt::ZERO,
+            alignment: None,
+            float_info: None,
+            style_id: None,
+        });
+
+        let (pages, warnings) = capture_table_warnings(|| {
+            layout_section(
+                &blocks,
+                &small_config(),
+                None,
+                Pt::ZERO,
+                Pt::new(14.0),
+                None,
+            )
+        });
+
+        assert!(
+            warnings.is_empty(),
+            "unexpected table warnings: {warnings:?}"
+        );
+        let flattened: Vec<_> = texts_per_page(&pages).into_iter().flatten().collect();
+        assert_eq!(
+            flattened.iter().filter(|text| *text == "heading").count(),
+            1
+        );
+        for index in 0..24 {
+            let needle = format!("row{index}");
+            assert_eq!(flattened.iter().filter(|text| *text == &needle).count(), 1);
+        }
+    }
+
+    #[test]
+    fn keep_next_does_not_force_an_entire_multi_page_table() {
+        let blocks = vec![
+            styled_para_block("heading", true, false),
+            one_column_table(&[
+                ("row0", true),
+                ("row1", false),
+                ("row2", false),
+                ("row3", false),
+                ("row4", false),
+                ("row5", false),
+            ]),
+        ];
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        assert!(pages.len() > 1);
+        assert!(texts_per_page(&pages)[0]
+            .iter()
+            .any(|text| text == "heading"));
+    }
+
+    #[test]
+    fn explicit_page_break_terminates_keep_next_group() {
+        let blocks = vec![
+            styled_para_block("heading", true, false),
+            styled_para_block("forced", false, true),
+        ];
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let per_page = texts_per_page(&pages);
+        assert!(per_page[0].iter().any(|text| text == "heading"));
+        assert!(per_page[1].iter().any(|text| text == "forced"));
+    }
+
+    #[test]
+    fn oversized_keep_next_chain_makes_progress_without_duplicates() {
+        let mut blocks = Vec::new();
+        for index in 0..6 {
+            blocks.push(styled_para_block(
+                &format!("chain{index}"),
+                index < 5,
+                false,
+            ));
+        }
+        let pages = layout_section(
+            &blocks,
+            &small_config(),
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+        let flattened: Vec<_> = texts_per_page(&pages).into_iter().flatten().collect();
+        for index in 0..6 {
+            let needle = format!("chain{index}");
+            assert_eq!(flattened.iter().filter(|text| *text == &needle).count(), 1);
+        }
     }
 
     /// A floating table whose laid-out height exceeds the available

--- a/src/render/layout/table/grid.rs
+++ b/src/render/layout/table/grid.rs
@@ -44,19 +44,7 @@ pub(super) fn build_row_groups(rows: &[TableRowInput], measured: &MeasuredTable)
     let mut i = 0;
     while i < rows.len() {
         let start = i;
-        // Extend through vMerge Continue rows.
-        i += 1;
-        while i < rows.len() {
-            let has_continue = rows[i]
-                .cells
-                .iter()
-                .any(|c| c.vertical_merge == Some(VerticalMergeState::Continue));
-            if has_continue {
-                i += 1;
-            } else {
-                break;
-            }
-        }
+        i = row_group_end(rows, start);
         let height: Pt = measured.rows[start..i]
             .iter()
             .map(|mr| mr.height + mr.border_gap_below)
@@ -82,6 +70,20 @@ pub(super) fn build_row_groups(rows: &[TableRowInput], measured: &MeasuredTable)
         });
     }
     groups
+}
+
+/// Return the exclusive end of the paginator's atomic row group at `start`.
+pub(super) fn row_group_end(rows: &[TableRowInput], start: usize) -> usize {
+    let mut end = start + 1;
+    while end < rows.len()
+        && rows[end]
+            .cells
+            .iter()
+            .any(|cell| cell.vertical_merge == Some(VerticalMergeState::Continue))
+    {
+        end += 1;
+    }
+    end
 }
 
 fn cell_has_nested_table(cell: &TableCellInput) -> bool {

--- a/src/render/layout/table/mod.rs
+++ b/src/render/layout/table/mod.rs
@@ -135,8 +135,9 @@ pub struct TablePaginationConfig {
     pub suppress_first_row_top: bool,
 }
 
-pub(crate) struct TablePaginationHeights<'a, F> {
-    pub(crate) config: &'a TablePaginationConfig,
+pub(crate) struct TablePaginationHeights<F> {
+    pub(crate) available_height: Pt,
+    pub(crate) suppress_first_row_top: bool,
     pub(crate) page_height_for_slice: F,
 }
 
@@ -164,7 +165,8 @@ pub fn layout_table_paginated(
         borders,
         measure_text,
         TablePaginationHeights {
-            config: pagination,
+            available_height: pagination.available_height,
+            suppress_first_row_top: pagination.suppress_first_row_top,
             page_height_for_slice: |_| page_height,
         },
     )
@@ -177,14 +179,13 @@ pub(crate) fn layout_table_paginated_with_page_heights(
     default_line_height: Pt,
     borders: Option<&TableBorderConfig>,
     measure_text: super::paragraph::MeasureTextFn<'_>,
-    pagination: TablePaginationHeights<'_, impl FnMut(usize) -> Pt>,
+    pagination: TablePaginationHeights<impl FnMut(usize) -> Pt>,
 ) -> Vec<TableSlice> {
     let TablePaginationHeights {
-        config: pagination,
+        available_height,
+        suppress_first_row_top,
         mut page_height_for_slice,
     } = pagination;
-    let available_height = pagination.available_height;
-    let suppress_first_row_top = pagination.suppress_first_row_top;
     if rows.is_empty() || col_widths.is_empty() {
         return vec![TableSlice {
             commands: Vec::new(),
@@ -1633,11 +1634,8 @@ mod tests {
             None,
             None,
             TablePaginationHeights {
-                config: &TablePaginationConfig {
-                    available_height: Pt::new(30.0),
-                    page_height: Pt::new(30.0),
-                    suppress_first_row_top: false,
-                },
+                available_height: Pt::new(30.0),
+                suppress_first_row_top: false,
                 page_height_for_slice: |slice_index| match slice_index {
                     1 => Pt::new(30.0),
                     _ => Pt::new(60.0),

--- a/src/render/layout/table/mod.rs
+++ b/src/render/layout/table/mod.rs
@@ -135,6 +135,11 @@ pub struct TablePaginationConfig {
     pub suppress_first_row_top: bool,
 }
 
+pub(crate) struct TablePaginationHeights<'a, F> {
+    pub(crate) config: &'a TablePaginationConfig,
+    pub(crate) page_height_for_slice: F,
+}
+
 /// Lay out a table with page splitting at row boundaries.
 ///
 /// §17.4.49: header rows repeat on each continuation page.
@@ -150,8 +155,35 @@ pub fn layout_table_paginated(
     measure_text: super::paragraph::MeasureTextFn<'_>,
     pagination: &TablePaginationConfig,
 ) -> Vec<TableSlice> {
-    let available_height = pagination.available_height;
     let page_height = pagination.page_height;
+    layout_table_paginated_with_page_heights(
+        rows,
+        col_widths,
+        _constraints,
+        default_line_height,
+        borders,
+        measure_text,
+        TablePaginationHeights {
+            config: pagination,
+            page_height_for_slice: |_| page_height,
+        },
+    )
+}
+
+pub(crate) fn layout_table_paginated_with_page_heights(
+    rows: &[TableRowInput],
+    col_widths: &[Pt],
+    _constraints: &BoxConstraints,
+    default_line_height: Pt,
+    borders: Option<&TableBorderConfig>,
+    measure_text: super::paragraph::MeasureTextFn<'_>,
+    pagination: TablePaginationHeights<'_, impl FnMut(usize) -> Pt>,
+) -> Vec<TableSlice> {
+    let TablePaginationHeights {
+        config: pagination,
+        mut page_height_for_slice,
+    } = pagination;
+    let available_height = pagination.available_height;
     let suppress_first_row_top = pagination.suppress_first_row_top;
     if rows.is_empty() || col_widths.is_empty() {
         return vec![TableSlice {
@@ -219,7 +251,7 @@ pub fn layout_table_paginated(
                 });
                 slices.push(std::mem::take(&mut current_slice));
                 // New page: start with header rows (if any).
-                remaining = page_height;
+                remaining = page_height_for_slice(slices.len());
                 if header_count > 0 {
                     current_slice.push(SliceItem::Range(0..header_count));
                     remaining -= header_height;
@@ -250,7 +282,7 @@ pub fn layout_table_paginated(
                                 mr: sub.first,
                             });
                             slices.push(std::mem::take(&mut current_slice));
-                            remaining = page_height;
+                            remaining = page_height_for_slice(slices.len());
                             if header_count > 0 {
                                 current_slice.push(SliceItem::Range(0..header_count));
                                 remaining -= header_height;
@@ -282,7 +314,7 @@ pub fn layout_table_paginated(
 
         // No split possible — move the whole group to the next page.
         slices.push(std::mem::take(&mut current_slice));
-        remaining = page_height;
+        remaining = page_height_for_slice(slices.len());
         // §17.4.49: prepend the repeating header rows only when this group
         // sits past the headers. When advancing because a header row itself
         // doesn't fit, the row is part of the table's first appearance —
@@ -1580,5 +1612,50 @@ mod tests {
             .count();
         assert_eq!(count0, 3, "slice 0: header (1) + body0 (2)");
         assert_eq!(count1, 3, "slice 1: header repeated (1) + body1 (2)");
+    }
+
+    #[test]
+    fn continuation_slices_use_their_own_page_heights() {
+        let rows = (0..4)
+            .map(|_| {
+                let mut row = tall_row(2);
+                row.cant_split = Some(true);
+                row
+            })
+            .collect::<Vec<_>>();
+        let col_widths = vec![Pt::new(40.0)];
+
+        let slices = layout_table_paginated_with_page_heights(
+            &rows,
+            &col_widths,
+            &body_constraints(),
+            Pt::new(14.0),
+            None,
+            None,
+            TablePaginationHeights {
+                config: &TablePaginationConfig {
+                    available_height: Pt::new(30.0),
+                    page_height: Pt::new(30.0),
+                    suppress_first_row_top: false,
+                },
+                page_height_for_slice: |slice_index| match slice_index {
+                    1 => Pt::new(30.0),
+                    _ => Pt::new(60.0),
+                },
+            },
+        );
+
+        let row_counts = slices
+            .iter()
+            .map(|slice| {
+                slice
+                    .commands
+                    .iter()
+                    .filter(|command| matches!(command, DrawCommand::Text { .. }))
+                    .count()
+                    / 2
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(row_counts, vec![1, 1, 2]);
     }
 }

--- a/src/render/layout/table/mod.rs
+++ b/src/render/layout/table/mod.rs
@@ -20,9 +20,44 @@ pub use grid::compute_column_widths;
 pub use types::*;
 
 use emit::{emit_split_row, emit_table_rows, TableCommandBuffers};
-use grid::build_row_groups;
+use grid::{build_row_groups, row_group_end};
 use measure::measure_table_rows;
 use split::{find_row_cut, split_row_at, RowCutInput};
+
+/// Measure the first atomic paginator row group without emitting table commands.
+///
+/// The following row is included only to resolve the group's shared bottom
+/// border; later rows and groups are neither measured nor paginated.
+pub(crate) fn measure_leading_table_group_height(
+    rows: &[TableRowInput],
+    col_widths: &[Pt],
+    default_line_height: Pt,
+    borders: Option<&TableBorderConfig>,
+    measure_text: super::paragraph::MeasureTextFn<'_>,
+    suppress_first_row_top: bool,
+) -> Option<Pt> {
+    if rows.is_empty() || col_widths.is_empty() {
+        return None;
+    }
+
+    let group_end = row_group_end(rows, 0);
+    let measured_end = (group_end + 1).min(rows.len());
+    let measured = measure_table_rows(
+        &rows[..measured_end],
+        col_widths,
+        default_line_height,
+        borders,
+        measure_text,
+        suppress_first_row_top,
+    );
+
+    Some(
+        measured.rows[..group_end]
+            .iter()
+            .map(|row| row.height + row.border_gap_below)
+            .sum(),
+    )
+}
 
 /// Lay out a table: compute column widths, lay out cells, emit borders.
 ///

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -91,9 +91,12 @@ use crate::render::layout::build::{
     build_section_blocks, default_line_height, BuildContext, BuildState,
 };
 use crate::render::layout::draw_command::LayoutedPage;
-use crate::render::layout::header_footer::{render_headers_footers, HeaderFooterBlocks, PageRange};
+use crate::render::layout::header_footer::{
+    render_headers_footers, HeaderFooterBlocks, HeaderFooterClearance, PageRange,
+};
 use crate::render::layout::page::PageConfig;
-use crate::render::layout::section::layout_section;
+use crate::render::layout::section::layout_section_with_clearance;
+use crate::render::resolve::header_footer::HeaderFooterSet;
 use crate::render::resolve::ResolvedDocument;
 
 /// Render a parsed DOCX document to PDF bytes.
@@ -219,20 +222,26 @@ pub fn layout_document(
 
     // §17.6.22: track continuation state for `Continuous` section breaks.
     let mut pending_continuation: Option<layout::section::ContinuationState> = None;
+    let even_and_odd = resolved.even_and_odd_headers;
 
     // Phase 1: layout all sections to determine total page count.
     for (section_idx, section) in resolved.sections.iter().enumerate() {
-        // §17.6.2: if header/footer content extends past the body margin,
-        // push the body start down (or bottom up) so content doesn't overlap.
-        let config = adjust_margins_for_header_footer(
-            PageConfig::from_section(&section.properties),
+        let config = PageConfig::from_section(&section.properties);
+        state.page_config = config.clone();
+        let logical_page_base = layout::header_footer::next_logical_page_base(
+            next_logical,
+            section.properties.page_number_type.as_ref(),
+        );
+        let clearance = measure_header_footer_clearance(
+            &config,
             section,
             &ctx,
             &mut state,
             dlh,
+            even_and_odd,
+            logical_page_base,
         );
 
-        state.page_config = config.clone();
         let built = build_section_blocks(section, &config, &ctx, &mut state);
         let measure_fn = |text: &str,
                           font: &layout::fragment::FontProps|
@@ -249,13 +258,14 @@ pub fn layout_document(
                 None
             };
 
-        let mut pages = layout_section(
+        let mut pages = layout_section_with_clearance(
             &built.blocks,
             &config,
             Some(&measure_fn),
             separator_indent,
             dlh,
             continuation,
+            &clearance,
         );
 
         // Collect endnotes for rendering at document end.
@@ -281,10 +291,6 @@ pub fn layout_document(
 
         let page_start = all_pages.len();
         all_pages.append(&mut pages);
-        let logical_page_base = layout::header_footer::next_logical_page_base(
-            next_logical,
-            section.properties.page_number_type.as_ref(),
-        );
         let pages_in_section = all_pages.len() - page_start;
         next_logical = logical_page_base + pages_in_section;
         section_hf.push(SectionHfInfo {
@@ -299,7 +305,6 @@ pub fn layout_document(
 
     // Phase 2: render headers/footers with correct NUMPAGES (total page count).
     let total_pages = all_pages.len();
-    let even_and_odd = resolved.even_and_odd_headers;
     for info in &section_hf {
         state.page_config = info.config.clone();
         render_headers_footers(
@@ -375,95 +380,111 @@ pub fn layout_document(
     all_pages
 }
 
-/// §17.6.2: if header or footer content extends past the body margin,
-/// adjust margins so body text starts after the header / ends before
-/// the footer.
-///
-/// Each section can supply up to three header parts (default / first /
-/// even) and three footer parts. To keep the body region consistent
-/// across pages within a section, we compute the extent as the
-/// **maximum** across every populated slot — the body starts low
-/// enough to clear the tallest header, and ends high enough to clear
-/// the tallest footer. Per-page slot variation in height is
-/// uncommon in real documents (Word styles all three slots
-/// identically by default), so this conservative allocation is
-/// indistinguishable from per-page adjustment in the typical case
-/// while keeping body geometry stable.
-fn adjust_margins_for_header_footer(
-    mut config: PageConfig,
+/// Measure each populated header/footer slot independently so pagination can
+/// reserve the slot selected for each physical page.
+fn measure_header_footer_clearance(
+    config: &PageConfig,
     section: &crate::render::resolve::sections::ResolvedSection,
     ctx: &layout::build::BuildContext,
     state: &mut BuildState,
     default_line_height: dimension::Pt,
-) -> PageConfig {
-    let content_width = config.content_width();
-    let header_slots = [
-        section.headers.default.as_deref(),
-        section.headers.first.as_deref(),
-        section.headers.even.as_deref(),
-    ];
-    let footer_slots = [
-        section.footers.default.as_deref(),
-        section.footers.first.as_deref(),
-        section.footers.even.as_deref(),
-    ];
+    even_and_odd: bool,
+    logical_page_base: usize,
+) -> HeaderFooterClearance {
+    let headers =
+        HeaderFooterSet {
+            default: section.headers.default.as_deref().map(|blocks| {
+                measure_header_bottom(blocks, config, ctx, state, default_line_height)
+            }),
+            first: section.headers.first.as_deref().map(|blocks| {
+                measure_header_bottom(blocks, config, ctx, state, default_line_height)
+            }),
+            even: section.headers.even.as_deref().map(|blocks| {
+                measure_header_bottom(blocks, config, ctx, state, default_line_height)
+            }),
+        };
+    let footers =
+        HeaderFooterSet {
+            default: section.footers.default.as_deref().map(|blocks| {
+                measure_footer_extent(blocks, config, ctx, state, default_line_height)
+            }),
+            first: section.footers.first.as_deref().map(|blocks| {
+                measure_footer_extent(blocks, config, ctx, state, default_line_height)
+            }),
+            even: section.footers.even.as_deref().map(|blocks| {
+                measure_footer_extent(blocks, config, ctx, state, default_line_height)
+            }),
+        };
 
-    let mut max_header_bottom = dimension::Pt::ZERO;
-    for blocks in header_slots.iter().flatten() {
-        let hf = layout::build::build_header_footer_content(blocks, ctx, state);
-        let result =
-            layout::section::stack_blocks(&hf.blocks, content_width, default_line_height, None);
+    HeaderFooterClearance::new(
+        config,
+        headers,
+        footers,
+        section.properties.title_page.unwrap_or(false),
+        even_and_odd,
+        logical_page_base,
+    )
+}
 
-        // §17.6.2: header_bottom is the greater of stacked block content and
-        // wrapTopAndBottom floating image extent, both measured from the header
-        // margin edge. wrapNone/behindDoc images are backgrounds and don't
-        // push body content down.
-        let blocks_bottom = config.header_margin + result.height;
-        let floats_bottom = hf
-            .floating_images
-            .iter()
-            .filter(|fi| fi.is_wrap_top_and_bottom())
-            .map(|fi| {
-                let y = match fi.y {
-                    layout::section::FloatingImageY::Absolute(y) => y,
-                    layout::section::FloatingImageY::RelativeToParagraph(off) => {
-                        config.header_margin + off
-                    }
-                };
-                y + fi.size.height
-            })
-            .fold(dimension::Pt::ZERO, |a, b| a.max(b));
-        max_header_bottom = max_header_bottom.max(blocks_bottom.max(floats_bottom));
-    }
-    if max_header_bottom > config.margins.top {
-        config.margins.top = max_header_bottom;
-    }
-
-    let mut max_footer_extent = dimension::Pt::ZERO;
-    for blocks in footer_slots.iter().flatten() {
-        let hf = layout::build::build_header_footer_content(blocks, ctx, state);
-        let result =
-            layout::section::stack_blocks(&hf.blocks, content_width, default_line_height, None);
-
-        let blocks_extent = config.footer_margin + result.height;
-        let floats_extent = hf
-            .floating_images
-            .iter()
-            .filter(|fi| fi.is_wrap_top_and_bottom())
-            .map(|fi| match fi.y {
-                layout::section::FloatingImageY::Absolute(y) => config.page_size.height - y,
+fn measure_header_bottom(
+    blocks: &[crate::model::Block],
+    config: &PageConfig,
+    ctx: &layout::build::BuildContext,
+    state: &mut BuildState,
+    default_line_height: dimension::Pt,
+) -> dimension::Pt {
+    let hf = layout::build::build_header_footer_content(blocks, ctx, state);
+    let result = layout::section::stack_blocks(
+        &hf.blocks,
+        config.content_width(),
+        default_line_height,
+        None,
+    );
+    let blocks_bottom = config.header_margin + result.height;
+    let floats_bottom = hf
+        .floating_images
+        .iter()
+        .filter(|fi| fi.is_wrap_top_and_bottom())
+        .map(|fi| {
+            let y = match fi.y {
+                layout::section::FloatingImageY::Absolute(y) => y,
                 layout::section::FloatingImageY::RelativeToParagraph(off) => {
-                    config.footer_margin + off + fi.size.height
+                    config.header_margin + off
                 }
-            })
-            .fold(dimension::Pt::ZERO, |a, b| a.max(b));
-        max_footer_extent = max_footer_extent.max(blocks_extent.max(floats_extent));
-    }
-    if max_footer_extent > config.margins.bottom {
-        config.margins.bottom = max_footer_extent;
-    }
+            };
+            y + fi.size.height
+        })
+        .fold(dimension::Pt::ZERO, |a, b| a.max(b));
+    blocks_bottom.max(floats_bottom)
+}
 
-    config
+fn measure_footer_extent(
+    blocks: &[crate::model::Block],
+    config: &PageConfig,
+    ctx: &layout::build::BuildContext,
+    state: &mut BuildState,
+    default_line_height: dimension::Pt,
+) -> dimension::Pt {
+    let hf = layout::build::build_header_footer_content(blocks, ctx, state);
+    let result = layout::section::stack_blocks(
+        &hf.blocks,
+        config.content_width(),
+        default_line_height,
+        None,
+    );
+    let blocks_extent = config.footer_margin + result.height;
+    let floats_extent = hf
+        .floating_images
+        .iter()
+        .filter(|fi| fi.is_wrap_top_and_bottom())
+        .map(|fi| match fi.y {
+            layout::section::FloatingImageY::Absolute(y) => config.page_size.height - y,
+            layout::section::FloatingImageY::RelativeToParagraph(off) => {
+                config.footer_margin + off + fi.size.height
+            }
+        })
+        .fold(dimension::Pt::ZERO, |a, b| a.max(b));
+    blocks_extent.max(floats_extent)
 }
 
 #[cfg(test)]
@@ -569,6 +590,88 @@ mod tests {
             .filter(|c| matches!(c, layout::draw_command::DrawCommand::Text { .. }))
             .count();
         assert_eq!(text_count, 2);
+    }
+
+    #[test]
+    fn body_layout_uses_the_header_and_footer_selected_for_each_page() {
+        use crate::model::dimension::{Dimension, Twips};
+
+        let mut doc = empty_doc();
+        let default_header = RelId::new("default-header");
+        let first_header = RelId::new("first-header");
+        let default_footer = RelId::new("default-footer");
+        let first_footer = RelId::new("first-footer");
+        doc.headers
+            .insert(default_header.clone(), vec![para("default header")]);
+        doc.headers.insert(
+            first_header.clone(),
+            vec![para("first header 1"), para("first header 2")],
+        );
+        doc.footers
+            .insert(default_footer.clone(), vec![para("default footer")]);
+        doc.footers.insert(
+            first_footer.clone(),
+            vec![para("first footer 1"), para("first footer 2")],
+        );
+        doc.body = (0..6).map(|index| para(&format!("body {index}"))).collect();
+        doc.final_section = SectionProperties {
+            page_size: Some(PageSize {
+                width: Some(Dimension::<Twips>::new(4000)),
+                height: Some(Dimension::<Twips>::new(2000)),
+                orientation: None,
+            }),
+            page_margins: Some(PageMargins {
+                top: Some(Dimension::<Twips>::new(200)),
+                right: Some(Dimension::<Twips>::new(200)),
+                bottom: Some(Dimension::<Twips>::new(200)),
+                left: Some(Dimension::<Twips>::new(200)),
+                header: Some(Dimension::<Twips>::new(100)),
+                footer: Some(Dimension::<Twips>::new(100)),
+                gutter: None,
+            }),
+            header_refs: SectionHeaderFooterRefs {
+                default: Some(default_header),
+                first: Some(first_header),
+                even: None,
+            },
+            footer_refs: SectionHeaderFooterRefs {
+                default: Some(default_footer),
+                first: Some(first_footer),
+                even: None,
+            },
+            title_page: Some(true),
+            ..Default::default()
+        };
+
+        let (_, pages) = resolve_and_layout(&doc);
+
+        assert_eq!(
+            pages.len(),
+            2,
+            "shorter default slots must expand page 2 body"
+        );
+        let body_positions = pages
+            .iter()
+            .map(|page| {
+                page.commands
+                    .iter()
+                    .filter_map(|command| match command {
+                        layout::draw_command::DrawCommand::Text { text, position, .. }
+                            if text.starts_with("body") =>
+                        {
+                            Some(position.y)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(body_positions[0].len(), 3);
+        assert_eq!(body_positions[1].len(), 3);
+        assert!(
+            body_positions[1][0] < body_positions[0][0],
+            "page 2 body must start below the shorter default header",
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -62,6 +62,25 @@ fn convert_simple_docx_to_pdf() {
 }
 
 #[test]
+fn decimal_integer_measurements_convert_without_preprocessing() {
+    let docx = simple_docx(
+        r#"<w:p>
+              <w:pPr><w:spacing w:before="252.00000000000003"/></w:pPr>
+              <w:r><w:t>Measured paragraph</w:t></w:r>
+            </w:p>
+            <w:tbl>
+              <w:tblPr><w:tblW w:w="5000.0" w:type="dxa"/></w:tblPr>
+              <w:tblGrid><w:gridCol w:w="5000.0"/></w:tblGrid>
+              <w:tr><w:tc><w:tcPr><w:tcW w:w="5000.0" w:type="dxa"/></w:tcPr>
+                <w:p><w:r><w:t>Measured cell</w:t></w:r></w:p>
+              </w:tc></w:tr>
+            </w:tbl>"#,
+    );
+    let pdf = dxpdf::convert(&docx).unwrap();
+    assert_eq!(&pdf[..5], b"%PDF-");
+}
+
+#[test]
 fn convert_formatted_docx_to_pdf() {
     let docx = simple_docx(
         r#"<w:p>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -51,6 +51,52 @@ fn simple_docx(body_content: &str) -> Vec<u8> {
     make_docx(&xml)
 }
 
+fn make_numbered_docx(document_xml: &str, numbering_xml: &str) -> Vec<u8> {
+    let buf = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(buf);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
+</Types>"#,
+    )
+    .unwrap();
+
+    zip.start_file("_rels/.rels", options).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#,
+    )
+    .unwrap();
+
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(document_xml.as_bytes()).unwrap();
+
+    zip.start_file("word/_rels/document.xml.rels", options)
+        .unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdNumbering" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+</Relationships>"#,
+    )
+    .unwrap();
+
+    zip.start_file("word/numbering.xml", options).unwrap();
+    zip.write_all(numbering_xml.as_bytes()).unwrap();
+
+    zip.finish().unwrap().into_inner()
+}
+
 #[test]
 fn convert_simple_docx_to_pdf() {
     let docx = simple_docx(r#"<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>"#);
@@ -58,6 +104,39 @@ fn convert_simple_docx_to_pdf() {
 
     // PDF should start with the magic bytes
     assert!(pdf.len() > 4);
+    assert_eq!(&pdf[..5], b"%PDF-");
+}
+
+#[test]
+fn convert_docx_with_two_numbering_definitions() {
+    use dxpdf::model::{AbstractNumId, NumId};
+
+    let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:body>
+        <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="11"/></w:numPr></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>
+        <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="12"/></w:numPr></w:pPr><w:r><w:t>Beta</w:t></w:r></w:p>
+      </w:body>
+    </w:document>"#;
+    let numbering = r#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="A%1."/></w:lvl></w:abstractNum>
+      <w:num w:numId="11"><w:abstractNumId w:val="1"/></w:num>
+      <w:abstractNum w:abstractNumId="2"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="B%1."/></w:lvl></w:abstractNum>
+      <w:num w:numId="12"><w:abstractNumId w:val="2"/></w:num>
+    </w:numbering>"#;
+    let docx = make_numbered_docx(document, numbering);
+    let parsed = dxpdf::docx::parse(&docx).unwrap();
+    assert_eq!(parsed.numbering.abstract_nums.len(), 2);
+    assert_eq!(parsed.numbering.numbering_instances.len(), 2);
+    assert_eq!(
+        parsed.numbering.numbering_instances[&NumId::new(11)].abstract_num_id,
+        AbstractNumId::new(1)
+    );
+    assert_eq!(
+        parsed.numbering.numbering_instances[&NumId::new(12)].abstract_num_id,
+        AbstractNumId::new(2)
+    );
+
+    let pdf = dxpdf::convert(&docx).unwrap();
     assert_eq!(&pdf[..5], b"%PDF-");
 }
 


### PR DESCRIPTION
Thanks for the awesome project! It's exactly what I needed for my docx-to-pdf workflows — the closest match I've found to Google Docs' pdf export

But while testing it on real Word documents, I ran into a few valid OOXML patterns that the renderer didn't handle yet, so I decided to dig in a bit and fix or implement them directly :)

LLMs were involved, if that's important

## Changes

### 1. Decimal-valued OOXML measurements

**Issue.** Some real DOCX files use decimal lexical forms for measurements that OOXML ultimately treats as integers. dxpdf rejected those files before it could render them.

**Fix.** Measurements now accept decimal input and round it to the nearest integer. This tolerance is limited to measurement values: identifiers such as numbering IDs remain strict integers. Semantically unsigned dimensions reject negative values, while signed fields such as offsets, indentation, baseline shifts, rotations, and crop insets remain valid.

### 2. Repeated numbering definitions

**Issue.** Documents with more than one `abstractNum` or `num` definition in `numbering.xml` could fail to parse, even when those definitions described ordinary native Word lists.

**Fix.** The parser now collects repeated definitions in source order, so each list instance resolves independently.

### 3. Paragraph justification

**Issue.** Paragraphs marked as fully justified were rendered as ordinary left-aligned text.

**Fix.** dxpdf now distributes the available width across expandable spaces on non-final lines while preserving the natural width of the final line.

### 4. Keep-next pagination

**Issue.** `keepNext` handling was incomplete around tables, allowing headings to be separated from the paragraph or first table row that follows them.

**Fix.** The layout pass now keeps a heading with its leading table group when the group fits on the next page, while retaining normal pagination when it does not.

### 5. Per-page header and footer clearance

**Issue.** Body layout reserved the tallest populated header and footer slots across an entire section. With `titlePg` or even/odd headers enabled, a tall first-page or even-page slot therefore reduced the body area on pages that selected a shorter slot.

**Fix.** Header and footer extents are now measured independently for the `first`, `default`, and `even` slots. Pagination selects the appropriate body boundaries for each physical page using the same slot-selection rules as header and footer rendering. Missing selected slots retain the configured page margins.

Tables, floating-table continuations, footnotes, keep-next decisions, and page breaks all use these per-page boundaries, keeping pagination internally consistent.

### 6. Non-breaking hyphen line wrapping

**Issue.** U+2011 non-breaking hyphens were treated as ordinary break points, which allowed identifiers such as `ID‑001` to split across lines.

**Fix.** The text splitter and line fitter now preserve a non-breaking hyphen within its word fragment and never break immediately after it.

None of these changes alter the public Rust or Python APIs, and no new dependencies were added.

### 7. Feature matrix accuracy

**Issue.** The README did not reflect the newly implemented numbering, justification, and keep-next support, and it implied exact row-height support even though the renderer currently implements minimum-height semantics.

**Fix.** The feature matrix now records the new capabilities and labels row-height behavior accurately.

## Verification

Verification was done using a real-world multi-document workflow consisting of A4 DOCX files converted directly to A4 PDFs without preprocessing. The test matrix covered native numbering, justification, keep-next pagination, decimal measurements, first/default/even header and footer selection, per-page body clearance, table continuations, floating tables, footnotes, hyperlinks, tables, and embedded images
