### PR TITLE
Follow-up fixes for #80: dimensions, paragraph floats, font faces, and text runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Each layout element (paragraphs, table cells, headers/footers) goes through thre
 
 ## OOXML Feature Coverage
 
-Validated against ISO 29500 (Office Open XML). **42 features fully implemented, 9 partial, 12 planned.**
+Validated against ISO 29500 (Office Open XML). **42 features fully implemented, 10 partial, 12 planned.**
 
 <details>
 <summary>Full feature matrix (click to expand)</summary>
@@ -225,7 +225,8 @@ Validated against ISO 29500 (Office Open XML). **42 features fully implemented, 
 | Feature | Status |
 |---|---|
 | Alignment (left, center, right) | ✅ |
-| Alignment (justify, distribute) | ✅ |
+| Alignment (justify) | ✅ |
+| Alignment (distribute) | ⚠️ scalar-based: combining marks and contextual scripts such as Arabic and Indic are not shaping-safe |
 | Spacing before/after, line spacing | ✅ auto/exact/atLeast |
 | Indentation (left, right, first-line, hanging) | ✅ |
 | Tab stops (left) | ✅ |

--- a/src/docx/parse/primitives/integer_measure.rs
+++ b/src/docx/parse/primitives/integer_measure.rs
@@ -1,30 +1,34 @@
 use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct IntegerMeasure(i64);
+pub(crate) struct IntegerMeasure {
+    value: i64,
+    negative: bool,
+}
 
 impl IntegerMeasure {
     pub(crate) fn value(self) -> i64 {
-        self.0
+        self.value
     }
 
     pub(crate) fn is_negative(&self) -> bool {
-        self.0 < 0
+        self.negative
     }
 }
 
 impl<'de> Deserialize<'de> for IntegerMeasure {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = String::deserialize(deserializer)?;
-        parse_integer_measure(&raw)
-            .map(Self)
-            .map_err(serde::de::Error::custom)
+        parse_integer_measure(&raw).map_err(serde::de::Error::custom)
     }
 }
 
-fn parse_integer_measure(raw: &str) -> Result<i64, &'static str> {
+fn parse_integer_measure(raw: &str) -> Result<IntegerMeasure, &'static str> {
     if let Ok(value) = raw.parse::<i64>() {
-        return Ok(value);
+        return Ok(IntegerMeasure {
+            value,
+            negative: raw.starts_with('-'),
+        });
     }
 
     let (negative, unsigned) = match raw.strip_prefix('-') {
@@ -53,7 +57,8 @@ fn parse_integer_measure(raw: &str) -> Result<i64, &'static str> {
     } else {
         rounded_magnitude
     };
-    i64::try_from(signed).map_err(|_| "measurement is outside the supported range")
+    let value = i64::try_from(signed).map_err(|_| "measurement is outside the supported range")?;
+    Ok(IntegerMeasure { value, negative })
 }
 
 #[cfg(test)]

--- a/src/docx/parse/primitives/units.rs
+++ b/src/docx/parse/primitives/units.rs
@@ -67,6 +67,25 @@ mod tests {
         h: Dimension<HalfPoints>,
     }
 
+    #[derive(Deserialize)]
+    struct NonnegativeTwips {
+        #[serde(
+            rename = "@val",
+            deserialize_with = "deserialize_nonnegative_dimension"
+        )]
+        val: Dimension<Twips>,
+    }
+
+    #[derive(Deserialize)]
+    struct OptionalNonnegativeTwips {
+        #[serde(
+            rename = "@val",
+            default,
+            deserialize_with = "deserialize_optional_nonnegative_dimension"
+        )]
+        val: Option<Dimension<Twips>>,
+    }
+
     #[test]
     fn twips_attribute_deserializes() {
         let v: TwipsVal = quick_xml::de::from_str(r#"<x val="720"/>"#).unwrap();
@@ -94,5 +113,30 @@ mod tests {
             "expected error, got {:?}",
             r.map(|v| v.val.raw())
         );
+    }
+
+    #[test]
+    fn negative_fractions_are_rejected_for_required_nonnegative_dimensions() {
+        for raw in ["-0.1", "-0.49"] {
+            let result: Result<NonnegativeTwips, _> =
+                quick_xml::de::from_str(&format!(r#"<x val="{raw}"/>"#));
+            if let Ok(value) = result {
+                panic!("{raw:?} must be rejected, got {}", value.val.raw());
+            }
+        }
+    }
+
+    #[test]
+    fn negative_fractions_are_rejected_for_optional_nonnegative_dimensions() {
+        for raw in ["-0.1", "-0.49"] {
+            let result: Result<OptionalNonnegativeTwips, _> =
+                quick_xml::de::from_str(&format!(r#"<x val="{raw}"/>"#));
+            if let Ok(value) = result {
+                panic!(
+                    "{raw:?} must be rejected, got {:?}",
+                    value.val.map(|dimension| dimension.raw())
+                );
+            }
+        }
     }
 }

--- a/src/docx/parse/properties/schema/measure.rs
+++ b/src/docx/parse/properties/schema/measure.rs
@@ -68,6 +68,16 @@ where
 mod tests {
     use super::*;
 
+    #[derive(Deserialize)]
+    struct NonnegativeTableMeasure {
+        #[serde(
+            rename = "tblW",
+            default,
+            deserialize_with = "deserialize_optional_nonnegative_table_measure"
+        )]
+        value: Option<TableMeasureXml>,
+    }
+
     fn parse(xml: &str) -> TableMeasure {
         let x: TableMeasureXml = quick_xml::de::from_str(xml).unwrap();
         x.into()
@@ -115,6 +125,20 @@ mod tests {
         match parse(r#"<tblW w="2500.5" type="dxa"/>"#) {
             TableMeasure::Twips(d) => assert_eq!(d.raw(), 2501),
             other => panic!("expected Twips, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn negative_fractions_are_rejected_for_nonnegative_table_measurements() {
+        for raw in ["-0.1", "-0.49"] {
+            let result: Result<NonnegativeTableMeasure, _> =
+                quick_xml::de::from_str(&format!(r#"<x><tblW w="{raw}" type="dxa"/></x>"#));
+            if let Ok(value) = result {
+                panic!(
+                    "{raw:?} must be rejected, got {:?}",
+                    value.value.map(TableMeasure::from)
+                );
+            }
         }
     }
 }

--- a/src/docx/whitespace_workaround.rs
+++ b/src/docx/whitespace_workaround.rs
@@ -17,11 +17,13 @@
 //!
 //! # The hack
 //!
-//! Before handing each XML part to quick-xml we scan for whitespace-only
-//! `<w:t...>...</w:t>` content and substitute each whitespace byte with a
+//! Before handing each XML part to quick-xml we resolve WordprocessingML text
+//! elements, then substitute each byte in a whitespace-only text node with a
 //! Private Use Area codepoint. quick-xml then sees a non-whitespace text node
-//! and preserves it. The body parser ([`crate::docx::parse::body`]) reverses
-//! the substitution when emitting [`RunElement::Text`].
+//! and preserves it. Resolving namespaces makes the workaround independent of
+//! the arbitrary prefix chosen by the DOCX producer. The body parser
+//! ([`crate::docx::parse::body`]) reverses the substitution when emitting
+//! [`RunElement::Text`].
 //!
 //! Sentinel mapping (BYTE → CHAR):
 //!
@@ -53,53 +55,28 @@ pub(crate) const WS_SENTINEL_LF: char = '\u{E00A}';
 /// Sentinel for ASCII carriage return (`0x0D`).
 pub(crate) const WS_SENTINEL_CR: char = '\u{E00D}';
 
-/// Pre-process an XML byte buffer so whitespace-only `<w:t>` content survives
-/// quick-xml's trimmer. Returns the original buffer unchanged when no
-/// substitution is needed (common case for binary parts).
+const WORDPROCESSINGML_NAMESPACE: &[u8] =
+    b"http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+/// Pre-process an XML byte buffer so whitespace-only WordprocessingML text
+/// content survives quick-xml's trimmer. Returns the original buffer unchanged
+/// when no substitution is needed.
 ///
 /// See module-level docs for why this is necessary.
 pub(crate) fn substitute_whitespace_only_runs(xml: &[u8]) -> Vec<u8> {
-    // Fast path: if no `<w:t` substring appears in the buffer there is nothing
-    // to scan. This avoids paying the per-byte loop cost on parts (images,
-    // theme XML, etc.) that have no run text.
-    if !contains_subslice(xml, b"<w:t") {
+    let spans = whitespace_only_wordprocessingml_text_spans(xml);
+    if spans.is_empty() {
         return xml.to_vec();
     }
 
     let mut out: Vec<u8> = Vec::with_capacity(xml.len());
-    let mut i = 0;
-    while i < xml.len() {
-        if let Some((content_start, content_end, close_tag_end)) = match_w_t_with_text(xml, i) {
-            let content = &xml[content_start..content_end];
-            if !content.is_empty() && content.iter().all(is_xml_whitespace_byte) {
-                // Copy bytes up to the start of the content (i.e. through `>`),
-                // emit sentinels for each whitespace byte, then resume after
-                // the original content (the closing `</w:t>` will be copied
-                // on the next iteration).
-                out.extend_from_slice(&xml[i..content_start]);
-                for &b in content {
-                    let sentinel = match b {
-                        b' ' => WS_SENTINEL_SPACE,
-                        b'\t' => WS_SENTINEL_TAB,
-                        b'\n' => WS_SENTINEL_LF,
-                        b'\r' => WS_SENTINEL_CR,
-                        _ => unreachable!("guarded by is_xml_whitespace_byte"),
-                    };
-                    let mut buf = [0u8; 4];
-                    out.extend_from_slice(sentinel.encode_utf8(&mut buf).as_bytes());
-                }
-                i = content_end;
-                continue;
-            }
-            // Not whitespace-only — leave the element alone but skip past the
-            // closing tag in one step so we don't rescan attribute bytes.
-            out.extend_from_slice(&xml[i..close_tag_end]);
-            i = close_tag_end;
-            continue;
-        }
-        out.push(xml[i]);
-        i += 1;
+    let mut cursor = 0;
+    for (start, end) in spans {
+        out.extend_from_slice(&xml[cursor..start]);
+        substitute_whitespace(&xml[start..end], &mut out);
+        cursor = end;
     }
+    out.extend_from_slice(&xml[cursor..]);
     out
 }
 
@@ -135,62 +112,70 @@ fn is_ws_sentinel(c: char) -> bool {
     )
 }
 
-/// True if `needle` appears anywhere in `haystack`.
-fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    haystack.windows(needle.len()).any(|w| w == needle)
-}
+/// Return source spans for whitespace-only text nodes directly inside
+/// WordprocessingML `<*:t>` elements. Namespace prefixes are resolved by
+/// quick-xml, so DrawingML and other XML vocabularies are not mutated.
+/// Malformed XML is left untouched.
+fn whitespace_only_wordprocessingml_text_spans(xml: &[u8]) -> Vec<(usize, usize)> {
+    use quick_xml::events::Event;
+    use quick_xml::name::ResolveResult;
+    use quick_xml::reader::NsReader;
 
-/// Try to match `<w:t...>CONTENT</w:t>` starting at `pos`.
-/// On success, returns `(content_start, content_end, close_tag_end)` where
-/// `close_tag_end` is the byte index just past `</w:t>`.
-///
-/// Self-closing `<w:t/>` is intentionally ignored — there is no content to
-/// preserve. Other `<w:t...` prefixes (`<w:tbl`, `<w:tab`) are rejected by the
-/// element-name boundary check.
-fn match_w_t_with_text(xml: &[u8], pos: usize) -> Option<(usize, usize, usize)> {
-    let prefix = b"<w:t";
-    if !xml[pos..].starts_with(prefix) {
-        return None;
-    }
-    let after_name = pos + prefix.len();
-    let next = *xml.get(after_name)?;
-    // `<w:t` must be followed by `>`, `/`, or whitespace. Anything else means
-    // we matched the prefix of a longer element name like `<w:tbl`.
-    if !matches!(next, b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r') {
-        return None;
-    }
-    // Find the byte index just past the start tag's closing `>`. We walk
-    // forward respecting attribute quoting so a `>` inside an attribute value
-    // doesn't fool us. (XML allows unescaped `>` in attribute values; OOXML
-    // never emits one but cheap to handle.)
-    let mut j = after_name;
-    let mut quote: Option<u8> = None;
-    let start_tag_end = loop {
-        let b = *xml.get(j)?;
-        match (quote, b) {
-            (None, b'>') => break j + 1,
-            (None, b'/') if xml.get(j + 1) == Some(&b'>') => return None, // self-closing
-            (None, b'"') | (None, b'\'') => quote = Some(b),
-            (Some(q), b) if b == q => quote = None,
+    let mut reader = NsReader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut spans = Vec::new();
+    let mut depth: usize = 0;
+    let mut text_depth = None;
+
+    loop {
+        let (namespace, event) = match reader.read_resolved_event() {
+            Ok(event) => event,
+            Err(_) => return Vec::new(),
+        };
+
+        match event {
+            Event::Start(start) => {
+                depth += 1;
+                if matches!(namespace, ResolveResult::Bound(uri) if uri.as_ref() == WORDPROCESSINGML_NAMESPACE)
+                    && start.local_name().as_ref() == b"t"
+                {
+                    text_depth = Some(depth);
+                }
+            }
+            Event::Text(text) if text_depth.is_some() => {
+                let content = text.as_ref();
+                if !content.is_empty() && content.iter().all(is_xml_whitespace_byte) {
+                    let end = reader.buffer_position() as usize;
+                    let Some(start) = end.checked_sub(content.len()) else {
+                        return Vec::new();
+                    };
+                    spans.push((start, end));
+                }
+            }
+            Event::End(_) => {
+                if text_depth == Some(depth) {
+                    text_depth = None;
+                }
+                depth = depth.saturating_sub(1);
+            }
+            Event::Eof => return if depth == 0 { spans } else { Vec::new() },
             _ => {}
         }
-        j += 1;
-    };
-
-    // Find the next `<` — that's the start of the closing tag (or a child
-    // element, but `<w:t>` per OOXML never has element children).
-    let lt = xml[start_tag_end..].iter().position(|&b| b == b'<')?;
-    let content_end = start_tag_end + lt;
-
-    let close = b"</w:t>";
-    if !xml[content_end..].starts_with(close) {
-        return None;
     }
-    let close_tag_end = content_end + close.len();
-    Some((start_tag_end, content_end, close_tag_end))
+}
+
+fn substitute_whitespace(content: &[u8], out: &mut Vec<u8>) {
+    for &b in content {
+        let sentinel = match b {
+            b' ' => WS_SENTINEL_SPACE,
+            b'\t' => WS_SENTINEL_TAB,
+            b'\n' => WS_SENTINEL_LF,
+            b'\r' => WS_SENTINEL_CR,
+            _ => unreachable!("caller only passes XML whitespace"),
+        };
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(sentinel.encode_utf8(&mut buf).as_bytes());
+    }
 }
 
 #[cfg(test)]
@@ -201,12 +186,23 @@ mod tests {
         String::from_utf8(b).unwrap()
     }
 
+    fn substitute_wml_fragment(fragment: &str) -> String {
+        let open =
+            r#"<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">"#;
+        let xml = format!("{open}{fragment}</w:root>");
+        let out = s(substitute_whitespace_only_runs(xml.as_bytes()));
+        out.strip_prefix(open)
+            .and_then(|out| out.strip_suffix("</w:root>"))
+            .unwrap()
+            .to_string()
+    }
+
     // ── substitute_whitespace_only_runs ──────────────────────────────────────
 
     #[test]
     fn single_space_preserve_is_substituted() {
         let xml = br#"<w:r><w:t xml:space="preserve"> </w:t></w:r>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(
             out,
             format!(
@@ -219,7 +215,7 @@ mod tests {
     #[test]
     fn three_spaces_preserve_each_substituted() {
         let xml = br#"<w:t xml:space="preserve">   </w:t>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         let expected = format!(
             r#"<w:t xml:space="preserve">{0}{0}{0}</w:t>"#,
             WS_SENTINEL_SPACE
@@ -232,14 +228,14 @@ mod tests {
         // Many third-party DOCX writers emit whitespace-only <w:t> without the
         // xml:space attribute. quick-xml strips them all the same.
         let xml = br#"<w:t> </w:t>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(out, format!("<w:t>{}</w:t>", WS_SENTINEL_SPACE));
     }
 
     #[test]
     fn tab_only_is_substituted() {
         let xml = b"<w:t xml:space=\"preserve\">\t</w:t>";
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(
             out,
             format!("<w:t xml:space=\"preserve\">{}</w:t>", WS_SENTINEL_TAB)
@@ -249,7 +245,7 @@ mod tests {
     #[test]
     fn lf_and_cr_substituted() {
         let xml = b"<w:t xml:space=\"preserve\">\r\n</w:t>";
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(
             out,
             format!(
@@ -264,21 +260,21 @@ mod tests {
         // Content has a non-whitespace char → quick-xml preserves it as-is,
         // we must not modify.
         let xml = br#"<w:t xml:space="preserve">hello world </w:t>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(out, std::str::from_utf8(xml).unwrap());
     }
 
     #[test]
     fn empty_w_t_is_left_untouched() {
         let xml = br#"<w:t></w:t>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(out, std::str::from_utf8(xml).unwrap());
     }
 
     #[test]
     fn self_closing_w_t_is_left_untouched() {
         let xml = br#"<w:t xml:space="preserve"/>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(out, std::str::from_utf8(xml).unwrap());
     }
 
@@ -287,14 +283,14 @@ mod tests {
         // `<w:tbl>`, `<w:tab/>`, `<w:tc>` all start with `<w:t` but should not
         // trigger substitution.
         let xml = br#"<w:tbl><w:tr><w:tc><w:tab/></w:tc></w:tr></w:tbl>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(out, std::str::from_utf8(xml).unwrap());
     }
 
     #[test]
     fn multiple_runs_in_one_buffer() {
         let xml = br#"<w:p><w:r><w:t>A</w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r><w:r><w:t>B</w:t></w:r></w:p>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         let expected = format!(
             r#"<w:p><w:r><w:t>A</w:t></w:r><w:r><w:t xml:space="preserve">{}</w:t></w:r><w:r><w:t>B</w:t></w:r></w:p>"#,
             WS_SENTINEL_SPACE
@@ -303,8 +299,15 @@ mod tests {
     }
 
     #[test]
-    fn buffer_without_w_t_is_unchanged_via_fast_path() {
-        let xml = br#"<a:theme><a:clrScheme/></a:theme>"#;
+    fn non_wordprocessingml_text_is_unchanged() {
+        let xml = br#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:t> </a:t></a:theme>"#;
+        let out = substitute_whitespace_only_runs(xml);
+        assert_eq!(&out[..], &xml[..]);
+    }
+
+    #[test]
+    fn malformed_xml_is_left_untouched() {
+        let xml = br#"<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:t> </w:t>"#;
         let out = substitute_whitespace_only_runs(xml);
         assert_eq!(&out[..], &xml[..]);
     }
@@ -322,7 +325,7 @@ mod tests {
         // The scanner must respect quoting so the inner `>` doesn't end the
         // start tag prematurely.
         let xml = br#"<w:t weird="a>b" xml:space="preserve"> </w:t>"#;
-        let out = s(substitute_whitespace_only_runs(xml));
+        let out = substitute_wml_fragment(std::str::from_utf8(xml).unwrap());
         assert_eq!(
             out,
             format!(
@@ -372,11 +375,7 @@ mod tests {
             t: TextXml,
         }
 
-        // The exact problem case from the Protokoll DOCX. We strip the `w:`
-        // namespace prefix here only because this test deserializes outside
-        // the real document context where namespaces are bound — the
-        // substitution function still operates on the canonical `<w:t>` form.
-        let original = br#"<r><w:t xml:space="preserve"> </w:t></r>"#;
+        let original = br#"<r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:t xml:space="preserve"> </w:t></r>"#;
         let preprocessed = substitute_whitespace_only_runs(original);
         let parsed: R = quick_xml::de::from_str(std::str::from_utf8(&preprocessed).unwrap())
             .expect("quick-xml parse");

--- a/src/docx/whitespace_workaround.rs
+++ b/src/docx/whitespace_workaround.rs
@@ -55,8 +55,18 @@ pub(crate) const WS_SENTINEL_LF: char = '\u{E00A}';
 /// Sentinel for ASCII carriage return (`0x0D`).
 pub(crate) const WS_SENTINEL_CR: char = '\u{E00D}';
 
-const WORDPROCESSINGML_NAMESPACE: &[u8] =
+const TRANSITIONAL_WORDPROCESSINGML_NAMESPACE: &[u8] =
     b"http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const STRICT_WORDPROCESSINGML_NAMESPACE: &[u8] =
+    b"http://purl.oclc.org/ooxml/wordprocessingml/main";
+
+#[inline]
+fn is_wordprocessingml_namespace(uri: &[u8]) -> bool {
+    matches!(
+        uri,
+        TRANSITIONAL_WORDPROCESSINGML_NAMESPACE | STRICT_WORDPROCESSINGML_NAMESPACE
+    )
+}
 
 /// Pre-process an XML byte buffer so whitespace-only WordprocessingML text
 /// content survives quick-xml's trimmer. Returns the original buffer unchanged
@@ -136,7 +146,7 @@ fn whitespace_only_wordprocessingml_text_spans(xml: &[u8]) -> Vec<(usize, usize)
         match event {
             Event::Start(start) => {
                 depth += 1;
-                if matches!(namespace, ResolveResult::Bound(uri) if uri.as_ref() == WORDPROCESSINGML_NAMESPACE)
+                if matches!(namespace, ResolveResult::Bound(uri) if is_wordprocessingml_namespace(uri.as_ref()))
                     && start.local_name().as_ref() == b"t"
                 {
                     text_depth = Some(depth);

--- a/src/render/fonts.rs
+++ b/src/render/fonts.rs
@@ -14,9 +14,10 @@
 //! becomes a real correctness bug. With per-render ownership, no such
 //! leakage is possible.
 
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::collections::HashMap;
 
+use skia_safe::font_style::{Slant, Weight, Width};
 use skia_safe::{Data, Font, FontMgr, FontStyle, Typeface};
 
 use crate::model::{EmbeddedFont, EmbeddedFontVariant};
@@ -122,12 +123,142 @@ struct EmbeddedRecord {
     bytes: Vec<u8>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FaceAlias {
+    family: String,
+    weight: i32,
+}
+
+#[derive(Clone, Debug)]
+enum AliasEntry {
+    Unique(FaceAlias),
+    Ambiguous,
+}
+
+#[derive(Default)]
+struct FaceAliasIndex {
+    aliases: HashMap<String, AliasEntry>,
+}
+
+impl FaceAliasIndex {
+    fn build(font_mgr: &FontMgr) -> Self {
+        let mut index = Self::default();
+
+        for family in font_mgr.family_names() {
+            let mut style_set = font_mgr.match_family(&family);
+            let count = style_set.count();
+            for face_index in 0..count {
+                let (style, style_name) = style_set.style(face_index);
+                let post_script_name = style_set
+                    .new_typeface(face_index)
+                    .and_then(|typeface| typeface.post_script_name());
+                index.insert_face(
+                    &family,
+                    style,
+                    style_name.as_deref(),
+                    post_script_name.as_deref(),
+                );
+            }
+        }
+
+        index
+    }
+
+    fn insert_face(
+        &mut self,
+        family: &str,
+        style: FontStyle,
+        style_name: Option<&str>,
+        post_script_name: Option<&str>,
+    ) {
+        // This compatibility layer resolves weight-bearing face names. Width
+        // and slant aliases require a fuller OpenType identity model.
+        if style.width() != Width::NORMAL || style.slant() != Slant::Upright {
+            return;
+        }
+
+        let alias = FaceAlias {
+            family: family.to_owned(),
+            weight: *style.weight(),
+        };
+
+        if let Some(style_name) = style_name.filter(|name| !name.trim().is_empty()) {
+            self.insert_alias(&format!("{family} {style_name}"), alias.clone());
+        }
+        if let Some(post_script_name) = post_script_name.filter(|name| !name.trim().is_empty()) {
+            self.insert_alias(post_script_name, alias.clone());
+        }
+        for weight_name in canonical_weight_names(alias.weight) {
+            self.insert_alias(&format!("{family} {weight_name}"), alias.clone());
+        }
+    }
+
+    fn insert_alias(&mut self, name: &str, alias: FaceAlias) {
+        use std::collections::hash_map::Entry;
+
+        match self.aliases.entry(face_name_key(name)) {
+            Entry::Vacant(entry) => {
+                entry.insert(AliasEntry::Unique(alias));
+            }
+            Entry::Occupied(mut entry) => match entry.get() {
+                AliasEntry::Unique(existing) if existing == &alias => {}
+                AliasEntry::Unique(_) => {
+                    entry.insert(AliasEntry::Ambiguous);
+                }
+                AliasEntry::Ambiguous => {}
+            },
+        }
+    }
+
+    fn resolve(&self, name: &str) -> Option<&FaceAlias> {
+        match self.aliases.get(&face_name_key(name))? {
+            AliasEntry::Unique(alias) => Some(alias),
+            AliasEntry::Ambiguous => None,
+        }
+    }
+}
+
+fn face_name_key(name: &str) -> String {
+    name.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn canonical_weight_names(weight: i32) -> &'static [&'static str] {
+    match weight {
+        100 => &["Thin", "Hairline"],
+        200 => &["ExtraLight", "Extra Light", "UltraLight", "Ultra Light"],
+        300 => &["Light"],
+        400 => &["Regular", "Normal"],
+        500 => &["Medium"],
+        600 => &["Semibold", "SemiBold", "Semi Bold", "DemiBold", "Demi Bold"],
+        700 => &["Bold"],
+        800 => &["ExtraBold", "Extra Bold", "UltraBold", "Ultra Bold"],
+        900 => &["Black", "Heavy"],
+        _ => &[],
+    }
+}
+
+fn merged_alias_weight(alias_weight: i32, requested_weight: i32) -> i32 {
+    alias_weight.max(requested_weight)
+}
+
+fn style_for_face_alias(alias: &FaceAlias, requested: FontStyle) -> FontStyle {
+    FontStyle::new(
+        Weight::from(merged_alias_weight(alias.weight, *requested.weight())),
+        Width::NORMAL,
+        requested.slant(),
+    )
+}
+
 // ─── FontRegistry ────────────────────────────────────────────────────────────
 
 pub struct FontRegistry {
     font_mgr: FontMgr,
     embedded: Vec<EmbeddedRecord>,
     embedded_index: HashMap<(String, EmbeddedFontVariant), EmbeddedFontId>,
+    system_face_aliases: OnceCell<FaceAliasIndex>,
     typefaces: RefCell<HashMap<TypefaceKey, TypefaceEntry>>,
 }
 
@@ -138,6 +269,7 @@ impl FontRegistry {
             font_mgr,
             embedded: Vec::new(),
             embedded_index: HashMap::new(),
+            system_face_aliases: OnceCell::new(),
             typefaces: RefCell::new(HashMap::new()),
         }
     }
@@ -250,6 +382,24 @@ impl FontRegistry {
         if let Some(tf) = match_exact(&self.font_mgr, family, style) {
             log::debug!("[font] '{}' {:?} → exact match", family, style);
             return system_entry(tf);
+        }
+
+        if let Some(alias) = self
+            .system_face_aliases
+            .get_or_init(|| FaceAliasIndex::build(&self.font_mgr))
+            .resolve(family)
+        {
+            let alias_style = style_for_face_alias(alias, style);
+            if let Some(tf) = match_exact(&self.font_mgr, &alias.family, alias_style) {
+                log::debug!(
+                    "[font] '{}' {:?} → face alias '{}' {:?}",
+                    family,
+                    style,
+                    alias.family,
+                    alias_style
+                );
+                return system_entry(tf);
+            }
         }
 
         if let Some((_, subs)) = FONT_SUBSTITUTIONS
@@ -541,9 +691,103 @@ impl FontCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use skia_safe::font_style::{Slant, Weight, Width};
 
     fn fmgr() -> FontMgr {
         FontMgr::new()
+    }
+
+    fn test_alias(family: &str, weight: i32) -> FaceAlias {
+        FaceAlias {
+            family: family.to_owned(),
+            weight,
+        }
+    }
+
+    #[test]
+    fn face_aliases_support_semibold_spellings() {
+        let mut index = FaceAliasIndex::default();
+        index.insert_face(
+            "Proxima Nova",
+            FontStyle::new(Weight::SEMI_BOLD, Width::NORMAL, Slant::Upright),
+            Some("Semibold"),
+            Some("ProximaNova-Semibold"),
+        );
+
+        for name in [
+            "Proxima Nova Semibold",
+            "Proxima Nova SemiBold",
+            "Proxima Nova Semi Bold",
+            "ProximaNova-Semibold",
+        ] {
+            let alias = index.resolve(name).expect("alias should resolve");
+            assert_eq!(alias.family, "Proxima Nova");
+            assert_eq!(alias.weight, *Weight::SEMI_BOLD);
+        }
+    }
+
+    #[test]
+    fn face_aliases_support_extra_bold_spellings() {
+        let mut index = FaceAliasIndex::default();
+        index.insert_face(
+            "Inter",
+            FontStyle::new(Weight::EXTRA_BOLD, Width::NORMAL, Slant::Upright),
+            Some("ExtraBold"),
+            Some("Inter-ExtraBold"),
+        );
+
+        for name in ["Inter ExtraBold", "Inter Extra Bold", "Inter-ExtraBold"] {
+            assert_eq!(
+                index.resolve(name).expect("alias should resolve").weight,
+                *Weight::EXTRA_BOLD
+            );
+        }
+    }
+
+    #[test]
+    fn face_alias_keys_ignore_case_and_repeated_whitespace() {
+        assert_eq!(
+            face_name_key("  Proxima   Nova SEMIBOLD "),
+            face_name_key("proxima nova semibold")
+        );
+    }
+
+    #[test]
+    fn face_alias_keys_preserve_punctuation() {
+        assert_ne!(face_name_key("A-B"), face_name_key("AB"));
+    }
+
+    #[test]
+    fn conflicting_face_aliases_are_ambiguous() {
+        let mut index = FaceAliasIndex::default();
+        index.insert_alias("Shared Alias", test_alias("Family A", 600));
+        index.insert_alias("Shared Alias", test_alias("Family B", 600));
+
+        assert!(index.resolve("Shared Alias").is_none());
+    }
+
+    #[test]
+    fn requested_weight_never_downgrades_face_alias_weight() {
+        assert_eq!(
+            merged_alias_weight(*Weight::SEMI_BOLD, *Weight::BOLD),
+            *Weight::BOLD
+        );
+        assert_eq!(
+            merged_alias_weight(*Weight::EXTRA_BOLD, *Weight::BOLD),
+            *Weight::EXTRA_BOLD
+        );
+    }
+
+    #[test]
+    fn face_alias_style_preserves_requested_slant() {
+        let alias = test_alias("Proxima Nova", *Weight::SEMI_BOLD);
+        let requested = FontStyle::new(Weight::NORMAL, Width::NORMAL, Slant::Italic);
+
+        let resolved = style_for_face_alias(&alias, requested);
+
+        assert_eq!(*resolved.weight(), *Weight::SEMI_BOLD);
+        assert_eq!(resolved.width(), Width::NORMAL);
+        assert_eq!(resolved.slant(), Slant::Italic);
     }
 
     /// Pull bytes from a guaranteed-available system typeface so tests don't

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -254,6 +254,18 @@ impl<'doc> PageReplayCheckpoint<'doc> {
     }
 }
 
+fn refresh_page_replay_checkpoint<'doc>(
+    state: &PageLayoutState<'doc>,
+    checkpoint: &mut PageReplayCheckpoint<'doc>,
+    marker: &mut (usize, usize),
+) {
+    let current_marker = (state.page_index, state.page_start_block);
+    if current_marker != *marker {
+        *checkpoint = PageReplayCheckpoint::capture(state);
+        *marker = current_marker;
+    }
+}
+
 impl ParagraphFloatCheckpoint {
     fn capture(state: &PageLayoutState<'_>) -> Self {
         Self {
@@ -590,11 +602,6 @@ pub(crate) fn layout_section_with_clearance(
     let mut block_idx = 0;
 
     'blocks: while block_idx < blocks.len() {
-        let page_marker = (state.page_index, state.page_start_block);
-        if page_marker != page_start_marker {
-            page_start_state = PageReplayCheckpoint::capture(&state);
-            page_start_marker = page_marker;
-        }
         let block = &blocks[block_idx];
         // §17.3.3.1: a deferred inline page break from the previous block
         // forces this block onto a new page.
@@ -605,6 +612,7 @@ pub(crate) fn layout_section_with_clearance(
                 state.prev_space_after = Pt::ZERO;
             }
         }
+        refresh_page_replay_checkpoint(&state, &mut page_start_state, &mut page_start_marker);
 
         match block {
             LayoutBlock::Paragraph {
@@ -691,6 +699,11 @@ pub(crate) fn layout_section_with_clearance(
                         }
                     }
                 }
+                refresh_page_replay_checkpoint(
+                    &state,
+                    &mut page_start_state,
+                    &mut page_start_marker,
+                );
 
                 let mut effective_style = style.clone_for_layout();
 

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -1274,6 +1274,7 @@ pub(crate) fn layout_section_with_clearance(
                         // longer the discriminant for registration.
                         let _ = is_anchor;
                     }
+                    block_idx += 1;
                     continue;
                 }
 

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -381,10 +381,81 @@ fn register_paragraph_floats(
     }
 }
 
+fn register_destination_paragraph_floats(
+    state: &mut PageLayoutState<'_>,
+    floating_images: &[FloatingImage],
+    floating_shapes: &[FloatingShape],
+    space_before: Pt,
+    col_width: Pt,
+) {
+    let content_top = state.cursor_y + space_before;
+    register_paragraph_floats(state, floating_images, floating_shapes, content_top);
+    for active_float in &state.page_floats {
+        if active_float.overlaps_y(state.cursor_y) && active_float.width >= col_width {
+            state.cursor_y = state.cursor_y.max(active_float.page_y_end);
+        }
+    }
+    float::prune_floats(&mut state.page_floats, state.cursor_y);
+}
+
 fn has_absolute_wrap_float(floating_images: &[FloatingImage]) -> bool {
     floating_images.iter().any(|image| {
         matches!(image.y, FloatingImageY::Absolute(_)) && image.wrap_mode.registers_as_wrap_float()
     })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ForwardScanBoundary {
+    None,
+    BeforeParagraphFloat,
+    AfterParagraphFloat,
+}
+
+fn scan_inline_page_boundary(
+    fragments: &[super::super::fragment::Fragment],
+    current_col: &mut usize,
+    num_cols: usize,
+) -> ForwardScanBoundary {
+    for (index, fragment) in fragments.iter().enumerate() {
+        match fragment {
+            super::super::fragment::Fragment::PageBreak { .. } => {
+                let has_following_content = fragments[index + 1..].iter().any(|fragment| {
+                    !matches!(fragment, super::super::fragment::Fragment::PageBreak { .. })
+                });
+                return if has_following_content {
+                    ForwardScanBoundary::BeforeParagraphFloat
+                } else {
+                    ForwardScanBoundary::AfterParagraphFloat
+                };
+            }
+            super::super::fragment::Fragment::ColumnBreak => {
+                if *current_col + 1 < num_cols {
+                    *current_col += 1;
+                } else {
+                    *current_col = 0;
+                    return ForwardScanBoundary::BeforeParagraphFloat;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ForwardScanBoundary::None
+}
+
+fn mark_absolute_float_relocation(
+    paragraph_content_placed: bool,
+    moves_to_new_page: bool,
+    block_idx: usize,
+    replay_block_idx: usize,
+    floating_images: &[FloatingImage],
+    relocated_blocks: &mut std::collections::HashSet<usize>,
+) -> bool {
+    !paragraph_content_placed
+        && moves_to_new_page
+        && block_idx > replay_block_idx
+        && has_absolute_wrap_float(floating_images)
+        && relocated_blocks.insert(block_idx)
 }
 
 fn paragraph_keep_next(block: &LayoutBlock) -> bool {
@@ -782,16 +853,21 @@ pub(crate) fn layout_section_with_clearance(
                 // current page. Only rescan when the page changes.
                 if state.abs_floats_dirty {
                     state.current_page_abs_floats.clear();
+                    let mut scan_col = state.current_col;
                     for (fi_idx, future_block) in
                         blocks[state.page_start_block..].iter().enumerate()
                     {
                         let future_block_idx = state.page_start_block + fi_idx;
                         if relocated_absolute_float_blocks.contains(&future_block_idx) {
-                            continue;
+                            if fi_idx == 0 {
+                                continue;
+                            }
+                            break;
                         }
                         if let LayoutBlock::Paragraph {
                             floating_images: fi_list,
                             page_break_before,
+                            fragments,
                             ..
                         } = future_block
                         {
@@ -800,20 +876,27 @@ pub(crate) fn layout_section_with_clearance(
                             if *page_break_before && fi_idx > 0 {
                                 break;
                             }
-                            for fi in fi_list {
-                                if fi.is_wrap_top_and_bottom() {
-                                    continue; // handled as block spacers, not floats
+                            let boundary =
+                                scan_inline_page_boundary(fragments, &mut scan_col, num_cols);
+                            if boundary != ForwardScanBoundary::BeforeParagraphFloat {
+                                for fi in fi_list {
+                                    if fi.is_wrap_top_and_bottom() {
+                                        continue; // handled as block spacers, not floats
+                                    }
+                                    if let FloatingImageY::Absolute(img_y) = fi.y {
+                                        state.current_page_abs_floats.push(float::ActiveFloat {
+                                            page_x: fi.x - fi.dist_left,
+                                            page_y_start: img_y,
+                                            page_y_end: img_y + fi.size.height,
+                                            width: fi.size.width + fi.dist_left + fi.dist_right,
+                                            source: float::FloatSource::Image,
+                                            wrap_text: fi.wrap_mode.wrap_text().into(),
+                                        });
+                                    }
                                 }
-                                if let FloatingImageY::Absolute(img_y) = fi.y {
-                                    state.current_page_abs_floats.push(float::ActiveFloat {
-                                        page_x: fi.x - fi.dist_left,
-                                        page_y_start: img_y,
-                                        page_y_end: img_y + fi.size.height,
-                                        width: fi.size.width + fi.dist_left + fi.dist_right,
-                                        source: float::FloatSource::Image,
-                                        wrap_text: fi.wrap_mode.wrap_text().into(),
-                                    });
-                                }
+                            }
+                            if boundary != ForwardScanBoundary::None {
+                                break;
                             }
                         }
                     }
@@ -892,14 +975,39 @@ pub(crate) fn layout_section_with_clearance(
                     // §17.3.3.1: force a new page for non-empty chunks that
                     // follow a page break.
                     if unresolved_page_break {
+                        if mark_absolute_float_relocation(
+                            paragraph_content_placed,
+                            true,
+                            block_idx,
+                            replay_block_idx,
+                            floating_images,
+                            &mut relocated_absolute_float_blocks,
+                        ) {
+                            page_replay_state.restore(&mut state);
+                            block_idx = replay_block_idx;
+                            continue 'blocks;
+                        }
+                        if !paragraph_content_placed {
+                            float_checkpoint.restore(&mut state);
+                        }
                         state.push_new_page(block_idx, &ctx);
                         state.prev_space_after = Pt::ZERO;
                         para_start_y = state.cursor_y;
+                        if !paragraph_content_placed {
+                            let col_width = config.columns[state.current_col].width;
+                            register_destination_paragraph_floats(
+                                &mut state,
+                                floating_images,
+                                floating_shapes,
+                                effective_style.space_before,
+                                col_width,
+                            );
+                        }
                         effective_style.page_y = state.cursor_y;
                         effective_style.page_x = col_x(state.current_col);
                         effective_style.page_content_width =
                             config.columns[state.current_col].width;
-                        effective_style.page_floats = Vec::new();
+                        effective_style.page_floats = state.page_floats.clone();
                     }
 
                     let col_chunks = split_at_column_breaks(page_chunk);
@@ -907,16 +1015,46 @@ pub(crate) fn layout_section_with_clearance(
                     for (chunk_idx, chunk) in col_chunks.iter().enumerate() {
                         // Advance to the next column for chunks after a column break.
                         if chunk_idx > 0 {
-                            if state.current_col + 1 < num_cols {
+                            let starts_new_page = state.current_col + 1 >= num_cols;
+                            if mark_absolute_float_relocation(
+                                paragraph_content_placed,
+                                starts_new_page,
+                                block_idx,
+                                replay_block_idx,
+                                floating_images,
+                                &mut relocated_absolute_float_blocks,
+                            ) {
+                                page_replay_state.restore(&mut state);
+                                block_idx = replay_block_idx;
+                                continue 'blocks;
+                            }
+                            if !paragraph_content_placed && starts_new_page {
+                                float_checkpoint.restore(&mut state);
+                            }
+                            if !starts_new_page {
                                 state.current_col += 1;
                             } else {
                                 // All columns full — new page, reset to column 0.
                                 state.push_new_page(block_idx, &ctx);
                             }
                             state.cursor_y = state.column_top;
+                            if !paragraph_content_placed && starts_new_page {
+                                let col_width = config.columns[state.current_col].width;
+                                register_destination_paragraph_floats(
+                                    &mut state,
+                                    floating_images,
+                                    floating_shapes,
+                                    effective_style.space_before,
+                                    col_width,
+                                );
+                            }
+                            effective_style.page_y = state.cursor_y;
                             effective_style.page_x = col_x(state.current_col);
                             effective_style.page_content_width =
                                 config.columns[state.current_col].width;
+                            if starts_new_page {
+                                effective_style.page_floats = state.page_floats.clone();
+                            }
                         }
 
                         let constraints = col_constraints(
@@ -936,12 +1074,14 @@ pub(crate) fn layout_section_with_clearance(
                             && state.cursor_y > state.column_top
                         {
                             let moves_to_new_page = state.current_col + 1 >= num_cols;
-                            if !paragraph_content_placed
-                                && moves_to_new_page
-                                && block_idx > replay_block_idx
-                                && has_absolute_wrap_float(floating_images)
-                                && relocated_absolute_float_blocks.insert(block_idx)
-                            {
+                            if mark_absolute_float_relocation(
+                                paragraph_content_placed,
+                                moves_to_new_page,
+                                block_idx,
+                                replay_block_idx,
+                                floating_images,
+                                &mut relocated_absolute_float_blocks,
+                            ) {
                                 // Earlier source-page text may already have
                                 // wrapped around this future float. Replay the
                                 // page without it before placing the owner on
@@ -961,23 +1101,14 @@ pub(crate) fn layout_section_with_clearance(
                             }
                             let destination_para_start_y = state.cursor_y;
                             if !paragraph_content_placed {
-                                let content_top = state.cursor_y + effective_style.space_before;
-                                register_paragraph_floats(
+                                let col_width = config.columns[state.current_col].width;
+                                register_destination_paragraph_floats(
                                     &mut state,
                                     floating_images,
                                     floating_shapes,
-                                    content_top,
+                                    effective_style.space_before,
+                                    col_width,
                                 );
-                                let col_width = config.columns[state.current_col].width;
-                                for active_float in &state.page_floats {
-                                    if active_float.overlaps_y(state.cursor_y)
-                                        && active_float.width >= col_width
-                                    {
-                                        state.cursor_y =
-                                            state.cursor_y.max(active_float.page_y_end);
-                                    }
-                                }
-                                float::prune_floats(&mut state.page_floats, state.cursor_y);
                             }
                             // Update para_start_y after page/column change so
                             // floating images use the correct position.
@@ -1012,7 +1143,7 @@ pub(crate) fn layout_section_with_clearance(
                             state.current_page.commands.push(cmd);
                         }
                         state.cursor_y += para.size.height;
-                        paragraph_content_placed = true;
+                        paragraph_content_placed |= !chunk.is_empty();
                     }
                     // The page break has been consumed by this non-empty chunk.
                     unresolved_page_break = false;

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -177,6 +177,83 @@ struct ParagraphFloatCheckpoint {
     cursor_y: Pt,
 }
 
+struct PageReplayCheckpoint<'doc> {
+    current_page: LayoutedPage,
+    cursor_y: Pt,
+    page_index: usize,
+    page_top: Pt,
+    current_col: usize,
+    column_top: Pt,
+    bottom: Pt,
+    page_footnotes: Vec<(
+        &'doc [super::super::fragment::Fragment],
+        &'doc ParagraphStyle,
+    )>,
+    first_on_section_page: bool,
+    prev_space_after: Pt,
+    prev_style_id: Option<StyleId>,
+    prev_borders: Option<ParagraphBorderStyle>,
+    page_floats: Vec<float::ActiveFloat>,
+    current_page_abs_floats: Vec<float::ActiveFloat>,
+    abs_floats_dirty: bool,
+    page_start_block: usize,
+    last_para_start_y: Pt,
+    prev_table_style_id: Option<StyleId>,
+    pending_page_break: bool,
+}
+
+impl<'doc> PageReplayCheckpoint<'doc> {
+    fn capture(state: &PageLayoutState<'doc>) -> Self {
+        Self {
+            current_page: state.current_page.clone(),
+            cursor_y: state.cursor_y,
+            page_index: state.page_index,
+            page_top: state.page_top,
+            current_col: state.current_col,
+            column_top: state.column_top,
+            bottom: state.bottom,
+            page_footnotes: state.page_footnotes.clone(),
+            first_on_section_page: state.first_on_section_page,
+            prev_space_after: state.prev_space_after,
+            prev_style_id: state.prev_style_id.clone(),
+            prev_borders: state.prev_borders.clone(),
+            page_floats: state.page_floats.clone(),
+            current_page_abs_floats: state.current_page_abs_floats.clone(),
+            abs_floats_dirty: state.abs_floats_dirty,
+            page_start_block: state.page_start_block,
+            last_para_start_y: state.last_para_start_y,
+            prev_table_style_id: state.prev_table_style_id.clone(),
+            pending_page_break: state.pending_page_break,
+        }
+    }
+
+    fn restore(&self, state: &mut PageLayoutState<'doc>) {
+        state.current_page.clone_from(&self.current_page);
+        state.cursor_y = self.cursor_y;
+        state.page_index = self.page_index;
+        state.page_top = self.page_top;
+        state.current_col = self.current_col;
+        state.column_top = self.column_top;
+        state.bottom = self.bottom;
+        state.page_footnotes.clone_from(&self.page_footnotes);
+        state.first_on_section_page = self.first_on_section_page;
+        state.prev_space_after = self.prev_space_after;
+        state.prev_style_id.clone_from(&self.prev_style_id);
+        state.prev_borders.clone_from(&self.prev_borders);
+        state.page_floats.clone_from(&self.page_floats);
+        state
+            .current_page_abs_floats
+            .clone_from(&self.current_page_abs_floats);
+        state.abs_floats_dirty = self.abs_floats_dirty;
+        state.page_start_block = self.page_start_block;
+        state.last_para_start_y = self.last_para_start_y;
+        state
+            .prev_table_style_id
+            .clone_from(&self.prev_table_style_id);
+        state.pending_page_break = self.pending_page_break;
+    }
+}
+
 impl ParagraphFloatCheckpoint {
     fn capture(state: &PageLayoutState<'_>) -> Self {
         Self {
@@ -288,6 +365,12 @@ fn register_paragraph_floats(
             state.page_floats.push(float_entry);
         }
     }
+}
+
+fn has_absolute_wrap_float(floating_images: &[FloatingImage]) -> bool {
+    floating_images.iter().any(|image| {
+        matches!(image.y, FloatingImageY::Absolute(_)) && image.wrap_mode.registers_as_wrap_float()
+    })
 }
 
 fn paragraph_keep_next(block: &LayoutBlock) -> bool {
@@ -499,7 +582,20 @@ pub(crate) fn layout_section_with_clearance(
     };
     let col_x = |col: usize| -> Pt { config.margins.left + config.columns[col].x_offset };
 
-    for (block_idx, block) in blocks.iter().enumerate() {
+    // A forward-scanned absolute float can later move to another page. Keep
+    // those owners out of the source page's next scan while replaying it.
+    let mut relocated_absolute_float_blocks = std::collections::HashSet::new();
+    let mut page_start_state = PageReplayCheckpoint::capture(&state);
+    let mut page_start_marker = (state.page_index, state.page_start_block);
+    let mut block_idx = 0;
+
+    'blocks: while block_idx < blocks.len() {
+        let page_marker = (state.page_index, state.page_start_block);
+        if page_marker != page_start_marker {
+            page_start_state = PageReplayCheckpoint::capture(&state);
+            page_start_marker = page_marker;
+        }
+        let block = &blocks[block_idx];
         // §17.3.3.1: a deferred inline page break from the previous block
         // forces this block onto a new page.
         if state.pending_page_break {
@@ -665,6 +761,10 @@ pub(crate) fn layout_section_with_clearance(
                     for (fi_idx, future_block) in
                         blocks[state.page_start_block..].iter().enumerate()
                     {
+                        let future_block_idx = state.page_start_block + fi_idx;
+                        if relocated_absolute_float_blocks.contains(&future_block_idx) {
+                            continue;
+                        }
                         if let LayoutBlock::Paragraph {
                             floating_images: fi_list,
                             page_break_before,
@@ -811,6 +911,21 @@ pub(crate) fn layout_section_with_clearance(
                         if state.cursor_y + para.size.height > state.bottom
                             && state.cursor_y > state.column_top
                         {
+                            let moves_to_new_page = state.current_col + 1 >= num_cols;
+                            if !paragraph_content_placed
+                                && moves_to_new_page
+                                && block_idx > state.page_start_block
+                                && has_absolute_wrap_float(floating_images)
+                                && relocated_absolute_float_blocks.insert(block_idx)
+                            {
+                                // Earlier source-page text may already have
+                                // wrapped around this future float. Replay the
+                                // page without it before placing the owner on
+                                // its destination page.
+                                page_start_state.restore(&mut state);
+                                block_idx = state.page_start_block;
+                                continue 'blocks;
+                            }
                             if !paragraph_content_placed {
                                 float_checkpoint.restore(&mut state);
                             }
@@ -1219,6 +1334,7 @@ pub(crate) fn layout_section_with_clearance(
                 state.prev_table_style_id = style_id.clone();
             }
         }
+        block_idx += 1;
     }
 
     // Flush remaining footnotes and push the last page.

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -256,13 +256,15 @@ impl<'doc> PageReplayCheckpoint<'doc> {
 
 fn refresh_page_replay_checkpoint<'doc>(
     state: &PageLayoutState<'doc>,
+    block_idx: usize,
     checkpoint: &mut PageReplayCheckpoint<'doc>,
-    marker: &mut (usize, usize),
+    checkpoint_page_index: &mut usize,
+    replay_block_idx: &mut usize,
 ) {
-    let current_marker = (state.page_index, state.page_start_block);
-    if current_marker != *marker {
+    if state.page_index != *checkpoint_page_index {
         *checkpoint = PageReplayCheckpoint::capture(state);
-        *marker = current_marker;
+        *checkpoint_page_index = state.page_index;
+        *replay_block_idx = block_idx;
     }
 }
 
@@ -597,8 +599,9 @@ pub(crate) fn layout_section_with_clearance(
     // A forward-scanned absolute float can later move to another page. Keep
     // those owners out of the source page's next scan while replaying it.
     let mut relocated_absolute_float_blocks = std::collections::HashSet::new();
-    let mut page_start_state = PageReplayCheckpoint::capture(&state);
-    let mut page_start_marker = (state.page_index, state.page_start_block);
+    let mut page_replay_state = PageReplayCheckpoint::capture(&state);
+    let mut checkpoint_page_index = state.page_index;
+    let mut replay_block_idx = 0;
     let mut block_idx = 0;
 
     'blocks: while block_idx < blocks.len() {
@@ -612,7 +615,13 @@ pub(crate) fn layout_section_with_clearance(
                 state.prev_space_after = Pt::ZERO;
             }
         }
-        refresh_page_replay_checkpoint(&state, &mut page_start_state, &mut page_start_marker);
+        refresh_page_replay_checkpoint(
+            &state,
+            block_idx,
+            &mut page_replay_state,
+            &mut checkpoint_page_index,
+            &mut replay_block_idx,
+        );
 
         match block {
             LayoutBlock::Paragraph {
@@ -701,8 +710,10 @@ pub(crate) fn layout_section_with_clearance(
                 }
                 refresh_page_replay_checkpoint(
                     &state,
-                    &mut page_start_state,
-                    &mut page_start_marker,
+                    block_idx,
+                    &mut page_replay_state,
+                    &mut checkpoint_page_index,
+                    &mut replay_block_idx,
                 );
 
                 let mut effective_style = style.clone_for_layout();
@@ -927,7 +938,7 @@ pub(crate) fn layout_section_with_clearance(
                             let moves_to_new_page = state.current_col + 1 >= num_cols;
                             if !paragraph_content_placed
                                 && moves_to_new_page
-                                && block_idx > state.page_start_block
+                                && block_idx > replay_block_idx
                                 && has_absolute_wrap_float(floating_images)
                                 && relocated_absolute_float_blocks.insert(block_idx)
                             {
@@ -935,8 +946,8 @@ pub(crate) fn layout_section_with_clearance(
                                 // wrapped around this future float. Replay the
                                 // page without it before placing the owner on
                                 // its destination page.
-                                page_start_state.restore(&mut state);
-                                block_idx = state.page_start_block;
+                                page_replay_state.restore(&mut state);
+                                block_idx = replay_block_idx;
                                 continue 'blocks;
                             }
                             if !paragraph_content_placed {

--- a/src/render/layout/section/layout.rs
+++ b/src/render/layout/section/layout.rs
@@ -17,7 +17,9 @@ use super::floating_table::{
 use super::helpers::{
     render_page_footnotes, split_at_column_breaks, split_at_page_breaks, table_x_offset,
 };
-use super::types::{ContinuationState, FloatingImageY, LayoutBlock};
+use super::types::{
+    ContinuationState, FloatingImage, FloatingImageY, FloatingShape, LayoutBlock, WrapMode,
+};
 use super::FLOAT_DEDUP_EPSILON_PT;
 use super::FOOTNOTE_SEPARATOR_GAP;
 use crate::model::StyleId;
@@ -166,6 +168,125 @@ impl<'doc> PageLayoutState<'doc> {
         self.flush_footnotes(ctx);
         self.pages.push(self.current_page);
         self.pages
+    }
+}
+
+struct ParagraphFloatCheckpoint {
+    command_count: usize,
+    page_floats: Vec<float::ActiveFloat>,
+    cursor_y: Pt,
+}
+
+impl ParagraphFloatCheckpoint {
+    fn capture(state: &PageLayoutState<'_>) -> Self {
+        Self {
+            command_count: state.current_page.commands.len(),
+            page_floats: state.page_floats.clone(),
+            cursor_y: state.cursor_y,
+        }
+    }
+
+    fn restore(&self, state: &mut PageLayoutState<'_>) {
+        state.current_page.commands.truncate(self.command_count);
+        state.page_floats.clone_from(&self.page_floats);
+        state.cursor_y = self.cursor_y;
+    }
+}
+
+fn register_paragraph_floats(
+    state: &mut PageLayoutState<'_>,
+    floating_images: &[FloatingImage],
+    floating_shapes: &[FloatingShape],
+    content_top: Pt,
+) {
+    for fi in floating_images {
+        let (y_start, y_end) = match fi.y {
+            FloatingImageY::RelativeToParagraph(offset) => {
+                (content_top + offset, content_top + offset + fi.size.height)
+            }
+            FloatingImageY::Absolute(img_y) => (img_y, img_y + fi.size.height),
+        };
+        if fi.is_wrap_top_and_bottom() {
+            let img_y = match fi.y {
+                FloatingImageY::Absolute(y) => y,
+                FloatingImageY::RelativeToParagraph(offset) => content_top + offset,
+            };
+            state.current_page.commands.push(DrawCommand::Image {
+                rect: PtRect::from_xywh(fi.x, img_y, fi.size.width, fi.size.height),
+                image_data: fi.image_data.clone(),
+                src_rect: fi.src_rect,
+            });
+            if y_end > state.cursor_y {
+                state.cursor_y = y_end;
+            }
+        } else {
+            let float_entry = float::ActiveFloat {
+                page_x: fi.x - fi.dist_left,
+                page_y_start: y_start,
+                page_y_end: y_end,
+                width: fi.size.width + fi.dist_left + fi.dist_right,
+                source: float::FloatSource::Image,
+                wrap_text: fi.wrap_mode.wrap_text().into(),
+            };
+            log::debug!(
+                "[layout]   register image float: x={:.1} y={:.1}-{:.1} w={:.1}",
+                float_entry.page_x.raw(),
+                y_start.raw(),
+                y_end.raw(),
+                float_entry.width.raw()
+            );
+            state.page_floats.push(float_entry);
+        }
+    }
+
+    for fs in floating_shapes {
+        if matches!(fs.wrap_mode, WrapMode::None) {
+            continue;
+        }
+        let (y_start, y_end) = match fs.y {
+            FloatingImageY::RelativeToParagraph(offset) => {
+                (content_top + offset, content_top + offset + fs.size.height)
+            }
+            FloatingImageY::Absolute(y) => (y, y + fs.size.height),
+        };
+        if fs.is_wrap_top_and_bottom() {
+            let shape_y = match fs.y {
+                FloatingImageY::Absolute(y) => y,
+                FloatingImageY::RelativeToParagraph(offset) => content_top + offset,
+            };
+            state.current_page.commands.push(DrawCommand::Path {
+                origin: crate::render::geometry::PtOffset::new(fs.x, shape_y),
+                rotation: fs.rotation,
+                flip_h: fs.flip_h,
+                flip_v: fs.flip_v,
+                extent: fs.size,
+                paths: fs.paths.clone(),
+                fill: fs.fill.clone(),
+                stroke: fs.stroke.clone(),
+                effects: fs.effects.clone(),
+            });
+            if y_end > state.cursor_y {
+                state.cursor_y = y_end;
+            }
+        } else {
+            let float_entry = float::ActiveFloat {
+                page_x: fs.x - fs.dist_left,
+                page_y_start: y_start,
+                page_y_end: y_end,
+                width: fs.size.width + fs.dist_left + fs.dist_right,
+                source: float::FloatSource::Shape,
+                wrap_text: fs.wrap_mode.wrap_text().into(),
+            };
+            log::debug!(
+                "[layout]   register shape float: x={:.1} y={:.1}-{:.1} w={:.1} mode={:?}",
+                float_entry.page_x.raw(),
+                y_start.raw(),
+                y_end.raw(),
+                float_entry.width.raw(),
+                fs.wrap_mode
+            );
+            state.page_floats.push(float_entry);
+        }
     }
 }
 
@@ -525,110 +646,14 @@ pub(crate) fn layout_section_with_clearance(
                 // and cursor_y advances past them — they act as block spacers.
                 // §20.4.2.10: paragraph-relative floats use the content area
                 // top (after space_before), not the total paragraph box top.
+                let float_checkpoint = ParagraphFloatCheckpoint::capture(&state);
                 let content_top = state.cursor_y + effective_style.space_before;
-                for fi in floating_images.iter() {
-                    let (y_start, y_end) = match fi.y {
-                        FloatingImageY::RelativeToParagraph(offset) => {
-                            (content_top + offset, content_top + offset + fi.size.height)
-                        }
-                        FloatingImageY::Absolute(img_y) => (img_y, img_y + fi.size.height),
-                    };
-                    if fi.is_wrap_top_and_bottom() {
-                        // §20.4.2.18: emit now and advance cursor past the image.
-                        let img_y = match fi.y {
-                            FloatingImageY::Absolute(y) => y,
-                            FloatingImageY::RelativeToParagraph(offset) => content_top + offset,
-                        };
-                        state.current_page.commands.push(DrawCommand::Image {
-                            rect: PtRect::from_xywh(fi.x, img_y, fi.size.width, fi.size.height),
-                            image_data: fi.image_data.clone(),
-                            src_rect: fi.src_rect,
-                        });
-                        if y_end > state.cursor_y {
-                            state.cursor_y = y_end;
-                        }
-                    } else {
-                        // §20.4.2.3: use distL/distR for text distance from float.
-                        let float_entry = float::ActiveFloat {
-                            page_x: fi.x - fi.dist_left,
-                            page_y_start: y_start,
-                            page_y_end: y_end,
-                            width: fi.size.width + fi.dist_left + fi.dist_right,
-                            source: float::FloatSource::Image,
-                            wrap_text: fi.wrap_mode.wrap_text().into(),
-                        };
-                        log::debug!(
-                            "[layout]   register image float: x={:.1} y={:.1}-{:.1} w={:.1}",
-                            float_entry.page_x.raw(),
-                            y_start.raw(),
-                            y_end.raw(),
-                            float_entry.width.raw()
-                        );
-                        state.page_floats.push(float_entry);
-                    }
-                }
-
-                // §20.4.2: register floating shapes (DrawingML). Parallels
-                // the image loop above but emits `DrawCommand::Path` for
-                // `wrapTopAndBottom` shapes and pushes an `ActiveFloat` with
-                // `FloatSource::Shape` for wrapping modes.
-                for fs in floating_shapes.iter() {
-                    use crate::render::layout::section::WrapMode;
-                    if matches!(fs.wrap_mode, WrapMode::None) {
-                        // wrapNone shapes do not participate in text flow —
-                        // they're emitted after the paragraph (below) with no
-                        // cursor impact.
-                        continue;
-                    }
-                    let (y_start, y_end) = match fs.y {
-                        FloatingImageY::RelativeToParagraph(offset) => {
-                            (content_top + offset, content_top + offset + fs.size.height)
-                        }
-                        FloatingImageY::Absolute(y) => (y, y + fs.size.height),
-                    };
-                    if fs.is_wrap_top_and_bottom() {
-                        // §20.4.2.18: emit now and advance cursor past the shape.
-                        let shape_y = match fs.y {
-                            FloatingImageY::Absolute(y) => y,
-                            FloatingImageY::RelativeToParagraph(offset) => content_top + offset,
-                        };
-                        state.current_page.commands.push(DrawCommand::Path {
-                            origin: crate::render::geometry::PtOffset::new(fs.x, shape_y),
-                            rotation: fs.rotation,
-                            flip_h: fs.flip_h,
-                            flip_v: fs.flip_v,
-                            extent: fs.size,
-                            paths: fs.paths.clone(),
-                            fill: fs.fill.clone(),
-                            stroke: fs.stroke.clone(),
-                            effects: fs.effects.clone(),
-                        });
-                        if y_end > state.cursor_y {
-                            state.cursor_y = y_end;
-                        }
-                    } else {
-                        // Square / Tight / Through — register as active float.
-                        // Tight/Through approximated as Square per the Tier 1
-                        // plan (docs/drawingml-text-wrap.md Phase E).
-                        let float_entry = float::ActiveFloat {
-                            page_x: fs.x - fs.dist_left,
-                            page_y_start: y_start,
-                            page_y_end: y_end,
-                            width: fs.size.width + fs.dist_left + fs.dist_right,
-                            source: float::FloatSource::Shape,
-                            wrap_text: fs.wrap_mode.wrap_text().into(),
-                        };
-                        log::debug!(
-                            "[layout]   register shape float: x={:.1} y={:.1}-{:.1} w={:.1} mode={:?}",
-                            float_entry.page_x.raw(),
-                            y_start.raw(),
-                            y_end.raw(),
-                            float_entry.width.raw(),
-                            fs.wrap_mode
-                        );
-                        state.page_floats.push(float_entry);
-                    }
-                }
+                register_paragraph_floats(
+                    &mut state,
+                    floating_images,
+                    floating_shapes,
+                    content_top,
+                );
 
                 // Prune expired floats.
                 float::prune_floats(&mut state.page_floats, state.cursor_y);
@@ -721,6 +746,7 @@ pub(crate) fn layout_section_with_clearance(
                 let page_chunks = split_at_page_breaks(fragments);
                 let mut para_start_y = state.cursor_y;
                 state.last_para_start_y = state.cursor_y;
+                let mut paragraph_content_placed = false;
 
                 // §17.3.3.1: track whether an unresolved page break remains
                 // after processing all chunks, so it can be deferred to the
@@ -785,15 +811,38 @@ pub(crate) fn layout_section_with_clearance(
                         if state.cursor_y + para.size.height > state.bottom
                             && state.cursor_y > state.column_top
                         {
+                            if !paragraph_content_placed {
+                                float_checkpoint.restore(&mut state);
+                            }
                             if state.current_col + 1 < num_cols {
                                 state.current_col += 1;
                                 state.cursor_y = state.column_top;
                             } else {
                                 state.push_new_page(block_idx, &ctx);
                             }
+                            let destination_para_start_y = state.cursor_y;
+                            if !paragraph_content_placed {
+                                let content_top = state.cursor_y + effective_style.space_before;
+                                register_paragraph_floats(
+                                    &mut state,
+                                    floating_images,
+                                    floating_shapes,
+                                    content_top,
+                                );
+                                let col_width = config.columns[state.current_col].width;
+                                for active_float in &state.page_floats {
+                                    if active_float.overlaps_y(state.cursor_y)
+                                        && active_float.width >= col_width
+                                    {
+                                        state.cursor_y =
+                                            state.cursor_y.max(active_float.page_y_end);
+                                    }
+                                }
+                                float::prune_floats(&mut state.page_floats, state.cursor_y);
+                            }
                             // Update para_start_y after page/column change so
                             // floating images use the correct position.
-                            para_start_y = state.cursor_y;
+                            para_start_y = destination_para_start_y;
                             effective_style.page_y = state.cursor_y;
                             effective_style.page_x = col_x(state.current_col);
                             effective_style.page_content_width =
@@ -824,6 +873,7 @@ pub(crate) fn layout_section_with_clearance(
                             state.current_page.commands.push(cmd);
                         }
                         state.cursor_y += para.size.height;
+                        paragraph_content_placed = true;
                     }
                     // The page break has been consumed by this non-empty chunk.
                     unresolved_page_break = false;

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -50,6 +50,7 @@ mod tests {
     };
     use crate::render::resolve::color::RgbColor;
     use crate::render::resolve::header_footer::HeaderFooterSet;
+    use crate::render::resolve::images::MediaEntry;
     use std::cell::Cell;
     use std::rc::Rc;
     use std::sync::{Mutex, Once};
@@ -135,6 +136,23 @@ mod tests {
             footnotes: vec![],
             floating_images: vec![],
             floating_shapes: vec![],
+        }
+    }
+
+    fn floating_image(wrap_mode: WrapMode, height: f32) -> FloatingImage {
+        FloatingImage {
+            image_data: MediaEntry {
+                data: Rc::from([]),
+                format: crate::model::ImageFormat::Png,
+            },
+            size: PtSize::new(Pt::new(80.0), Pt::new(height)),
+            src_rect: None,
+            x: Pt::new(10.0),
+            y: FloatingImageY::RelativeToParagraph(Pt::ZERO),
+            wrap_mode,
+            dist_left: Pt::ZERO,
+            dist_right: Pt::ZERO,
+            behind_doc: false,
         }
     }
 
@@ -409,6 +427,136 @@ mod tests {
         assert!(
             after_y > moved_last_y,
             "following paragraph at {after_y:?} overlaps moved paragraph ending at {moved_last_y:?}",
+        );
+    }
+
+    #[test]
+    fn moved_paragraph_keeps_its_wrap_float_during_destination_relayout() {
+        let config = small_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            true,
+            false,
+            1,
+        );
+        let moved = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("moved-{i}"), 80.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section_with_clearance(
+            &[para_block("before", 170.0), moved],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+            &clearance,
+        );
+
+        assert_eq!(pages.len(), 2);
+        let first_moved_x = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("moved-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("moved paragraph text on page 2");
+        assert!(
+            first_moved_x >= Pt::new(90.0),
+            "moved text at {first_moved_x:?} overlaps its 10-90pt float",
+        );
+    }
+
+    #[test]
+    fn moved_paragraph_relocates_top_and_bottom_float_to_destination_page() {
+        let config = small_config();
+        let clearance = HeaderFooterClearance::new(
+            &config,
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            HeaderFooterSet {
+                default: None,
+                first: Some(Pt::new(30.0)),
+                even: None,
+            },
+            true,
+            false,
+            1,
+        );
+        let moved = LayoutBlock::Paragraph {
+            fragments: vec![text_frag("moved", 170.0, 14.0)],
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![floating_image(WrapMode::TopAndBottom, 30.0)],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section_with_clearance(
+            &[para_block("before", 170.0), moved],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+            &clearance,
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert!(
+            !pages[0]
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. })),
+            "the moved paragraph must not leave its image on page 1",
+        );
+        let image_bottom = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Image { rect, .. } => Some(rect.origin.y + rect.size.height),
+                _ => None,
+            })
+            .expect("top-and-bottom image on page 2");
+        let text_y = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.as_ref() == "moved" => {
+                    Some(position.y)
+                }
+                _ => None,
+            })
+            .expect("moved paragraph text on page 2");
+        assert!(
+            text_y >= image_bottom,
+            "moved text at {text_y:?} must follow image ending at {image_bottom:?}",
         );
     }
 

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -636,6 +636,77 @@ mod tests {
     }
 
     #[test]
+    fn moved_absolute_float_does_not_replay_page_start_paragraph() {
+        let config = small_config();
+        let filler = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("filler-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let page_start = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("page-start-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let source = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[filler, page_start, source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 3);
+        let page_start_commands = pages
+            .iter()
+            .flat_map(|page| &page.commands)
+            .filter(|command| {
+                matches!(
+                    command,
+                    DrawCommand::Text { text, .. } if text.starts_with("page-start-")
+                )
+            })
+            .count();
+        assert_eq!(page_start_commands, 2);
+    }
+
+    #[test]
     fn moved_paragraph_relocates_top_and_bottom_float_to_destination_page() {
         let config = small_config();
         let clearance = HeaderFooterClearance::new(

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -578,6 +578,467 @@ mod tests {
     }
 
     #[test]
+    fn leading_inline_page_break_relayouts_source_page_after_float_relocation() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: std::iter::once(Fragment::PageBreak {
+                line_height: Pt::new(14.0),
+            })
+            .chain((0..2).map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0)))
+            .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 2);
+        let source_positions: Vec<_> = pages[0]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+
+        let owner_x = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("owner-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("owner text on destination page");
+        assert!(
+            owner_x >= Pt::new(90.0),
+            "owner text at {owner_x:?} overlaps its 10-90pt float"
+        );
+    }
+
+    #[test]
+    fn column_break_page_transition_drops_forward_floats_from_previous_page() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: std::iter::once(Fragment::ColumnBreak)
+                .chain((0..4).map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0)))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 3);
+        let source_positions: Vec<_> = pages[1]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+        assert!(
+            pages[2]
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. })),
+            "the relocated float must be emitted on page 3"
+        );
+    }
+
+    #[test]
+    fn nonempty_column_break_does_not_leak_future_float_to_source_page() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: std::iter::once(text_frag("before", 170.0, 14.0))
+                .chain(std::iter::once(Fragment::ColumnBreak))
+                .chain((0..4).map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0)))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 3);
+        let before_x = pages[0]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.as_ref() == "before" => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("text before the column break on page 1");
+        assert_eq!(before_x, Pt::new(10.0));
+        let source_positions: Vec<_> = pages[1]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+        assert!(pages[..2].iter().all(|page| {
+            !page
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. }))
+        }));
+        assert_eq!(
+            pages[2]
+                .commands
+                .iter()
+                .filter(|command| matches!(command, DrawCommand::Image { .. }))
+                .count(),
+            1
+        );
+        let owner_x = pages[2]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("owner-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("owner text on page 3");
+        assert!(owner_x >= Pt::new(90.0));
+    }
+
+    #[test]
+    fn leading_inline_column_break_relayouts_source_page_after_float_relocation() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: std::iter::once(Fragment::ColumnBreak)
+                .chain((0..2).map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0)))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 2);
+        let source_positions: Vec<_> = pages[0]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+        assert!(!pages[0]
+            .commands
+            .iter()
+            .any(|command| matches!(command, DrawCommand::Image { .. })));
+        assert_eq!(
+            pages[1]
+                .commands
+                .iter()
+                .filter(|command| matches!(command, DrawCommand::Image { .. }))
+                .count(),
+            1
+        );
+        let owner_x = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("owner-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("owner text on page 2");
+        assert!(owner_x >= Pt::new(90.0));
+    }
+
+    #[test]
+    fn nonempty_page_break_does_not_leak_future_float_to_source_page() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: std::iter::once(text_frag("before", 170.0, 14.0))
+                .chain(std::iter::once(Fragment::PageBreak {
+                    line_height: Pt::new(14.0),
+                }))
+                .chain((0..4).map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0)))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 3);
+        let before_x = pages[0]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.as_ref() == "before" => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("text before the page break on page 1");
+        assert_eq!(before_x, Pt::new(10.0));
+        let source_positions: Vec<_> = pages[1]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+        assert!(pages[..2].iter().all(|page| {
+            !page
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. }))
+        }));
+        assert_eq!(
+            pages[2]
+                .commands
+                .iter()
+                .filter(|command| matches!(command, DrawCommand::Image { .. }))
+                .count(),
+            1
+        );
+        let owner_x = pages[2]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("owner-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("owner text on page 3");
+        assert!(owner_x >= Pt::new(90.0));
+    }
+
+    #[test]
+    fn same_page_column_break_preserves_page_float_state() {
+        use crate::render::layout::page::ColumnGeometry;
+
+        let mut config = small_config();
+        config.columns = vec![
+            ColumnGeometry {
+                x_offset: Pt::ZERO,
+                width: Pt::new(85.0),
+            },
+            ColumnGeometry {
+                x_offset: Pt::new(95.0),
+                width: Pt::new(85.0),
+            },
+        ];
+        let source = LayoutBlock::Paragraph {
+            fragments: vec![
+                text_frag("before", 70.0, 14.0),
+                Fragment::ColumnBreak,
+                text_frag("after", 70.0, 14.0),
+            ],
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: vec![text_frag("owner", 70.0, 14.0)],
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 1);
+        let before_x = pages[0]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.as_ref() == "before" => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("text in the first column");
+        assert!(before_x >= Pt::new(90.0));
+        for expected in ["before", "after", "owner"] {
+            assert_eq!(
+                pages[0]
+                    .commands
+                    .iter()
+                    .filter(|command| {
+                        matches!(command, DrawCommand::Text { text, .. } if text.as_ref() == expected)
+                    })
+                    .count(),
+                1
+            );
+        }
+        assert_eq!(
+            pages[0]
+                .commands
+                .iter()
+                .filter(|command| matches!(command, DrawCommand::Image { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn moved_absolute_float_replays_from_first_affected_page_two_paragraph() {
         let config = small_config();
         let source = LayoutBlock::Paragraph {

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -578,6 +578,64 @@ mod tests {
     }
 
     #[test]
+    fn moved_absolute_float_replays_from_first_affected_page_two_paragraph() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: true,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[para_block("before", 170.0), source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 3);
+        let source_positions: Vec<_> = pages[1]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+        assert!(
+            pages[2]
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. })),
+            "the relocated float must be emitted on page 3"
+        );
+    }
+
+    #[test]
     fn moved_paragraph_relocates_top_and_bottom_float_to_destination_page() {
         let config = small_config();
         let clearance = HeaderFooterClearance::new(

--- a/src/render/layout/section/mod.rs
+++ b/src/render/layout/section/mod.rs
@@ -156,6 +156,13 @@ mod tests {
         }
     }
 
+    fn absolute_floating_image(wrap_mode: WrapMode, y: f32, height: f32) -> FloatingImage {
+        FloatingImage {
+            y: FloatingImageY::Absolute(Pt::new(y)),
+            ..floating_image(wrap_mode, height)
+        }
+    }
+
     fn styled_para_block(text: &str, keep_next: bool, page_break_before: bool) -> LayoutBlock {
         LayoutBlock::Paragraph {
             fragments: vec![text_frag(text, 30.0, 14.0)],
@@ -487,6 +494,86 @@ mod tests {
         assert!(
             first_moved_x >= Pt::new(90.0),
             "moved text at {first_moved_x:?} overlaps its 10-90pt float",
+        );
+    }
+
+    #[test]
+    fn moved_absolute_float_relayouts_earlier_source_page_text() {
+        let config = small_config();
+        let source = LayoutBlock::Paragraph {
+            fragments: (0..4)
+                .map(|i| text_frag(&format!("source-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![],
+            floating_shapes: vec![],
+        };
+        let owner = LayoutBlock::Paragraph {
+            fragments: (0..2)
+                .map(|i| text_frag(&format!("owner-{i}"), 170.0, 14.0))
+                .collect(),
+            style: ParagraphStyle::default(),
+            page_break_before: false,
+            footnotes: vec![],
+            floating_images: vec![absolute_floating_image(
+                WrapMode::Square(crate::model::WrapText::BothSides),
+                10.0,
+                42.0,
+            )],
+            floating_shapes: vec![],
+        };
+
+        let pages = layout_section(
+            &[source, owner],
+            &config,
+            None,
+            Pt::ZERO,
+            Pt::new(14.0),
+            None,
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert!(
+            !pages[0]
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. })),
+            "the relocated float must not remain on the source page"
+        );
+        assert!(
+            pages[1]
+                .commands
+                .iter()
+                .any(|command| matches!(command, DrawCommand::Image { .. })),
+            "the relocated float must be emitted on the destination page"
+        );
+        let source_positions: Vec<_> = pages[0]
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("source-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(source_positions, vec![Pt::new(10.0); 4]);
+
+        let owner_x = pages[1]
+            .commands
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::Text { text, position, .. } if text.starts_with("owner-") => {
+                    Some(position.x)
+                }
+                _ => None,
+            })
+            .expect("owner text on destination page");
+        assert!(
+            owner_x >= Pt::new(90.0),
+            "moved owner text at {owner_x:?} overlaps its 10-90pt float"
         );
     }
 

--- a/src/render/layout/table/emit.rs
+++ b/src/render/layout/table/emit.rs
@@ -146,8 +146,15 @@ fn emit_one_row(
             bufs.content_commands.push(cmd);
         }
 
+        let continues_below = vmerge_ctx.is_some_and(|(_, rows, row_idx)| {
+            row_idx + 1 < rows.len() && is_vmerge_continue(&rows[row_idx + 1], entry.grid_col)
+        });
         let bottom_border_gap = if has_next_in_slice {
-            border_width(b_bottom)
+            if continues_below {
+                mr.border_gap_below
+            } else {
+                border_width(b_bottom)
+            }
         } else {
             Pt::ZERO
         };

--- a/src/render/layout/table/mod.rs
+++ b/src/render/layout/table/mod.rs
@@ -1128,6 +1128,107 @@ mod tests {
     }
 
     #[test]
+    fn vmerge_outer_border_crosses_sibling_horizontal_border_gap() {
+        let border = TableBorderLine {
+            width: Pt::new(1.0),
+            color: RgbColor::BLACK,
+            style: TableBorderStyle::Single,
+        };
+        let borders = TableBorderConfig {
+            top: Some(border),
+            bottom: Some(border),
+            left: Some(border),
+            right: Some(border),
+            inside_h: Some(border),
+            inside_v: Some(border),
+        };
+        let merged_cell = |state| TableCellInput {
+            blocks: vec![],
+            margins: PtEdgeInsets::ZERO,
+            grid_span: 1,
+            shading: None,
+            cell_borders: None,
+            vertical_merge: Some(state),
+            vertical_align: CellVAlign::Top,
+        };
+        let rows = vec![
+            TableRowInput {
+                cells: vec![
+                    simple_cell("recipient"),
+                    merged_cell(VerticalMergeState::Restart),
+                ],
+                height_rule: None,
+                is_header: None,
+                cant_split: None,
+                grid_before: 0,
+                grid_after: 0,
+                border_overrides: None,
+            },
+            TableRowInput {
+                cells: vec![
+                    simple_cell("recipient bank"),
+                    merged_cell(VerticalMergeState::Continue),
+                ],
+                height_rule: None,
+                is_header: None,
+                cant_split: None,
+                grid_before: 0,
+                grid_after: 0,
+                border_overrides: None,
+            },
+            TableRowInput {
+                cells: vec![TableCellInput {
+                    blocks: vec![],
+                    margins: PtEdgeInsets::ZERO,
+                    grid_span: 2,
+                    shading: None,
+                    cell_borders: None,
+                    vertical_merge: None,
+                    vertical_align: CellVAlign::Top,
+                }],
+                height_rule: None,
+                is_header: None,
+                cant_split: None,
+                grid_before: 0,
+                grid_after: 0,
+                border_overrides: None,
+            },
+        ];
+
+        let result = layout_table(
+            &rows,
+            &[Pt::new(100.0), Pt::new(100.0)],
+            &body_constraints(),
+            Pt::new(14.0),
+            Some(&borders),
+            None,
+            false,
+        );
+        let mut right_edge_segments: Vec<_> = result
+            .commands
+            .iter()
+            .filter_map(|command| match command {
+                DrawCommand::Rect { rect, color }
+                    if *color == RgbColor::BLACK
+                        && rect.origin.x.raw() == 199.0
+                        && rect.size.width.raw() == 1.0 =>
+                {
+                    Some(*rect)
+                }
+                _ => None,
+            })
+            .collect();
+        right_edge_segments.sort_by(|a, b| a.origin.y.raw().total_cmp(&b.origin.y.raw()));
+
+        let first_end = right_edge_segments[0].origin.y + right_edge_segments[0].size.height;
+        let continuation_start = right_edge_segments[1].origin.y;
+        assert_eq!(
+            first_end, continuation_start,
+            "a vertically merged outer border must cross the inter-row border band"
+        );
+    }
+
+    #[test]
     fn valign_bottom_on_vmerge_restart_uses_span_height() {
         // §17.4.85 + §17.4.84: vAlign on a vMerge=Restart cell should
         // apply across the whole merged span, not just the first row.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -356,25 +356,31 @@ fn parse_zip_without_document_xml_returns_error() {
     );
 }
 
-/// Regression: a whitespace-only `<w:t xml:space="preserve">` between two
-/// other runs must round-trip the literal space into the parsed model.
-/// quick-xml's serde Deserializer trims whitespace-only `$text` content,
-/// which used to drop the separator and render `Label:Value` instead of
-/// `Label: Value`. The whitespace-workaround module substitutes a Private
-/// Use Area sentinel before parsing and reverses it during run conversion.
+/// Regression: a whitespace-only WordprocessingML text run must survive even
+/// when the document uses a namespace prefix other than the conventional `w`.
+/// quick-xml's serde Deserializer drops this separator before run conversion.
 #[test]
-fn whitespace_only_run_with_xml_space_preserve_roundtrips_to_space() {
+fn whitespace_only_run_with_an_alternate_wml_prefix_roundtrips() {
     use dxpdf::model::{Block, Inline, RunElement};
+    use dxpdf::render::layout::draw_command::DrawCommand;
 
-    // Same shape as the failing cell in the Protokoll DIN VDE document:
-    // bold label run, whitespace-only run with xml:space="preserve",
-    // value run with different formatting.
-    let docx = simple_docx(
-        r#"<w:p>
-            <w:r><w:rPr><w:b/></w:rPr><w:t>Label:</w:t></w:r>
-            <w:r><w:t xml:space="preserve"> </w:t></w:r>
-            <w:r><w:t>Value</w:t></w:r>
-        </w:p>"#,
+    // OOXML namespace prefixes are arbitrary. This uses a generated `ns0`
+    // prefix instead of the conventional `w` prefix.
+    let docx = make_docx(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ns0:document xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <ns0:body>
+    <ns0:p>
+      <ns0:r><ns0:t>Normal</ns0:t></ns0:r>
+      <ns0:r><ns0:t xml:space="preserve"> </ns0:t></ns0:r>
+      <ns0:r><ns0:rPr><ns0:b/></ns0:rPr><ns0:t>Styled</ns0:t></ns0:r>
+      <ns0:r><ns0:t xml:space="preserve"> </ns0:t></ns0:r>
+      <ns0:hyperlink ns0:anchor="destination">
+        <ns0:r><ns0:rPr><ns0:u ns0:val="single"/></ns0:rPr><ns0:t>Hyperlink</ns0:t></ns0:r>
+      </ns0:hyperlink>
+    </ns0:p>
+  </ns0:body>
+</ns0:document>"#,
     );
 
     let document = dxpdf::docx::parse(&docx).expect("parse");
@@ -383,22 +389,55 @@ fn whitespace_only_run_with_xml_space_preserve_roundtrips_to_space() {
         other => panic!("expected paragraph, got {other:?}"),
     };
 
-    let texts: Vec<&str> = para
-        .content
+    fn collect_text(inlines: &[Inline]) -> String {
+        inlines
+            .iter()
+            .map(|inline| match inline {
+                Inline::TextRun(run) => run
+                    .content
+                    .iter()
+                    .filter_map(|element| match element {
+                        RunElement::Text(text) => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>(),
+                Inline::Hyperlink(link) => collect_text(&link.content),
+                _ => String::new(),
+            })
+            .collect()
+    }
+
+    assert_eq!(
+        collect_text(&para.content),
+        "Normal Styled Hyperlink",
+        "whitespace-only runs must survive normal, styled, and hyperlink boundaries"
+    );
+
+    let (_, pages) = dxpdf::render::resolve_and_layout(&document);
+    let laid_out_text: String = pages
         .iter()
-        .filter_map(|inline| match inline {
-            Inline::TextRun(tr) => tr.content.iter().find_map(|el| match el {
-                RunElement::Text(t) => Some(t.as_str()),
-                _ => None,
-            }),
+        .flat_map(|page| &page.commands)
+        .filter_map(|command| match command {
+            DrawCommand::Text { text, .. } => Some(text.as_ref()),
             _ => None,
         })
         .collect();
 
     assert_eq!(
-        texts,
-        vec!["Label:", " ", "Value"],
-        "whitespace-only run must survive parsing as a literal space"
+        laid_out_text, "Normal Styled Hyperlink",
+        "layout must retain whitespace-only text runs"
+    );
+
+    let pdf = dxpdf::convert(&docx).expect("convert");
+    let parsed_pdf = lopdf::Document::load_mem(&pdf).expect("parse PDF");
+    let page_numbers: Vec<u32> = parsed_pdf.get_pages().into_keys().collect();
+    let pdf_text = parsed_pdf
+        .extract_text(&page_numbers)
+        .expect("extract PDF text");
+    assert_eq!(
+        pdf_text.replace('\n', ""),
+        "Normal Styled Hyperlink",
+        "PDF text must retain whitespace-only runs"
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -359,16 +359,15 @@ fn parse_zip_without_document_xml_returns_error() {
 /// Regression: a whitespace-only WordprocessingML text run must survive even
 /// when the document uses a namespace prefix other than the conventional `w`.
 /// quick-xml's serde Deserializer drops this separator before run conversion.
-#[test]
-fn whitespace_only_run_with_an_alternate_wml_prefix_roundtrips() {
+fn assert_whitespace_only_run_roundtrips(wml_namespace: &str) {
     use dxpdf::model::{Block, Inline, RunElement};
     use dxpdf::render::layout::draw_command::DrawCommand;
 
     // OOXML namespace prefixes are arbitrary. This uses a generated `ns0`
     // prefix instead of the conventional `w` prefix.
-    let docx = make_docx(
+    let docx = make_docx(&format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
-<ns0:document xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<ns0:document xmlns:ns0="{wml_namespace}">
   <ns0:body>
     <ns0:p>
       <ns0:r><ns0:t>Normal</ns0:t></ns0:r>
@@ -381,7 +380,7 @@ fn whitespace_only_run_with_an_alternate_wml_prefix_roundtrips() {
     </ns0:p>
   </ns0:body>
 </ns0:document>"#,
-    );
+    ));
 
     let document = dxpdf::docx::parse(&docx).expect("parse");
     let para = match document.body.first().expect("at least one block") {
@@ -439,6 +438,18 @@ fn whitespace_only_run_with_an_alternate_wml_prefix_roundtrips() {
         "Normal Styled Hyperlink",
         "PDF text must retain whitespace-only runs"
     );
+}
+
+#[test]
+fn whitespace_only_run_with_an_alternate_transitional_wml_prefix_roundtrips() {
+    assert_whitespace_only_run_roundtrips(
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+    );
+}
+
+#[test]
+fn whitespace_only_run_with_an_alternate_strict_wml_prefix_roundtrips() {
+    assert_whitespace_only_run_roundtrips("http://purl.oclc.org/ooxml/wordprocessingml/main");
 }
 
 #[test]


### PR DESCRIPTION
As mentioned in #80, its review uncovered a few bounded follow-up fixes that were better handled in a separate PR rather than added to an already broad change set

This PR applies eleven bounded follow-up fixes found while validating a broader set of DOCX documents. It addresses correctness edge cases, strengthens static face-name and namespace-aware text-run handling, and clarifies the distributed-alignment support boundary

The changes remain atomic and do not alter the public API

## 1. Negative fractional dimensions

**Issue:** signed decimal OOXML values such as `-0.1` and `-0.49` were rounded before nonnegative validation. They became integer zero and were incorrectly accepted by unsigned dimension deserializers.

**Fix:** integer measurements now retain whether the lexical input was negative. Required, optional, and table-related nonnegative dimensions validate that sign before accepting the rounded value. Signed measurements continue to preserve their existing behavior.

**Commit:** `2e93eb4` - `fix(docx): reject negative fractional dimensions`

## 2. Whitespace-only WordprocessingML runs

**Issue:** the existing quick-xml workaround protected whitespace-only `<w:t>` runs only when the producer used the conventional `w` namespace prefix. OOXML prefixes are arbitrary, so documents using a generated prefix such as `ns0` lost separators between normal, styled, and hyperlink runs.

**Fix:** the workaround now resolves the WordprocessingML namespace before selecting whitespace-only text nodes for sentinel substitution. It preserves the established behavior for valid `w:` documents while leaving DrawingML, other XML vocabularies, and malformed XML unchanged.

**Commit:** `06ab6e3` - `fix(docx): preserve whitespace-only runs across prefixes`

## 3. ISO Strict WordprocessingML runs

**Issue:** the namespace-aware workaround initially recognized only the Transitional WordprocessingML namespace. Valid ISO Strict documents use `http://purl.oclc.org/ooxml/wordprocessingml/main`, so whitespace-only runs still disappeared even with an arbitrary prefix.

**Fix:** the scanner now recognizes both Transitional and Strict WordprocessingML namespace URIs. The regression covers parsing, layout, and extracted PDF text for a Strict document using an alternate prefix.

**Commit:** `47e2069` - `fix(docx): preserve whitespace in Strict OOXML`

## 4. Paragraph floats after page moves

**Issue:** when an overflowing paragraph moved to a new page, page-local floats were cleared before destination relayout. The paragraph's own floating object was emitted later, but text had already been laid out without its wrap exclusion and could pass through the object.

**Fix:** paragraph-owned floats are translated and registered on the destination page before the paragraph is laid out again. Square, tight, through, and top-and-bottom wrapping therefore use the destination coordinates and body bounds consistently.

**Commit:** `86fdbca` - `fix(layout): relocate paragraph floats after page moves`

## 5. Source-page layout after float relocation

**Issue:** forward-scanned absolute floats can affect text preceding their owning paragraph. When that paragraph moved to the next page, the destination was corrected, but already-laid-out source-page text retained wrapping gaps for an object that no longer existed there.

**Fix:** when such an owner moves to a new physical page, the source page is replayed without that float before the owner is laid out on its destination page. The regression verifies the source text returns to its full width, while the float and wrapped owner text remain on the destination page.

**Commit:** `3f698ed` - `fix(layout): replay source page after float relocation`

## 6. Floating-table traversal

**Issue:** the floating-table layout branch consumed a table and then continued the manual block loop without advancing its cursor. The same table was therefore processed indefinitely, growing layout state until the process was terminated.

**Fix:** the branch now advances the block index before continuing. Existing floating-table overlap coverage now completes normally and verifies that both overlapping tables are emitted once.

**Commit:** `4ef65ac` - `fix(layout): advance after floating tables`

## 7. Replay checkpoints after page transitions

**Issue:** source-page replay state was refreshed only at the next block iteration. If a paragraph itself started a new page through `pageBreakBefore`, deferred breaks, or keep-with-next preflight, the saved checkpoint already contained that paragraph's rendered commands. Replaying it then duplicated source text and retained stale float wrapping.

**Fix:** replay state now refreshes immediately after each pre-layout page transition, before the paragraph can emit content. The regression covers a page-2 source paragraph affected by a later absolute float and verifies that it renders once, unwrapped, while the float owner moves to page 3.

**Commit:** `14db3e0` - `fix(layout): checkpoint page starts before replay`

## 8. Replay cursor alignment for mid-block page starts

**Issue:** when a page began during processing of the preceding paragraph or table, its replay checkpoint could contain already-rendered content while still pointing to the beginning of that block. Relocating a later absolute-float owner could therefore render the page-start content twice.

**Fix:** each replay checkpoint now stores the exact next block cursor corresponding to its captured state. Pages created inside paragraphs or table processing preserve completed chunks and slices, while replay resumes only from the next valid block boundary. The regression verifies that a paragraph moved to page 2 is emitted exactly once when a later float owner relocates.

**Commit:** `a3ef943` - `fix(layout): align replay state with block cursor`

## 9. Physical-page scope for wrapping floats

**Issue:** relocation and forward scanning treated several page-transition paths independently. Inline page breaks and column breaks that exhausted the final column could move a float owner without replaying affected source text, leave the next page with stale forward-float state, or fail to register the owner's float before destination relayout. The forward scan also crossed fragment-level physical page boundaries, allowing a float to affect text on pages where it was never emitted.

**Fix:** explicit page and page-crossing column breaks now share the absolute-float relocation path. Forward scanning tracks fragment-level page transitions and the current column, stopping before floats assigned to a later physical page while preserving page-level float state for same-page column changes. A moved owner's floats are registered before destination relayout, and empty leading chunks no longer suppress that registration.

The regression matrix covers leading inline page and column breaks, non-empty content before page-crossing breaks, stale intermediate-page wrapping, and a two-column same-page transition. It verifies page counts, text positions, single image emission, destination wrapping, and command uniqueness.

**Commit:** `87b2953` - `fix(layout): scope wrapping floats to physical pages`

## 10. Weighted static face names

**Issue:** a DOCX can name a standalone static face such as `Proxima Nova Semibold` without setting `w:b`. Skia exposes that font as family `Proxima Nova` with weight 600, so exact family validation rejected the request and eventually selected a fallback face.

**Fix:** each `FontRegistry` now builds a lazy alias index from the physical system faces exposed by Skia. It recognizes backend style names, PostScript names, and conventional spellings such as `Semibold`, `Semi Bold`, `ExtraBold`, and `Extra Bold`, then resolves the verified base family at the intrinsic numeric weight.

Exact family matching still has priority. Alias keys normalize only case and whitespace, ambiguous aliases are rejected, explicit bold can strengthen but not weaken the intrinsic weight, and the requested italic slant is preserved. Strict exact resolution used by the emoji path is unchanged.

**Commit:** `8ad9a82` - `fix(fonts): resolve weighted face names`

## 11. Vertical borders across merged rows

**Issue:** table measurement reserves a row-wide band for horizontal borders between physical rows. A vertically merged cell suppresses its intermediate bottom border, but border emission extended its side edges only by that suppressed border's width. When a sibling column supplied the horizontal border, the merged cell's vertical edge stopped before the reserved band and resumed after it, leaving a visible gap.

**Fix:** when a cell's vertical merge continues into the next physical row, its side borders now extend through the complete measured inter-row border band. Ordinary cells, the final row of a merge, row measurement, and pagination remain unchanged.

The regression constructs a vertically merged cell beside two ordinary rows and verifies that consecutive right-edge segments meet at exactly the same coordinate.

**Commit:** `7322c35` - `fix(table): close borders across vertical merges`

## Distributed alignment coverage

The feature matrix now lists ordinary justification as supported and distributed alignment as partial. The current implementation remains useful for simple scripts, but its scalar-based spacing is not shaping-safe for combining sequences or contextual scripts.

**Commit:** `dc572ba` - `docs: clarify distributed alignment coverage`

## Separate follow-up issues

Some findings require coordinated refactors across shaping, pagination, or font identity and were intentionally kept outside the scope of #80 and #86. I created separate issues to track them so that you, or anyone else who comes across them, will have all the context needed to address them properly 🙌

- [#82](https://github.com/nerdy-pro/dxpdf/issues/82) - render distributed alignment between shaped text clusters;
- [#83](https://github.com/nerdy-pro/dxpdf/issues/83) - relayout shared pages when continuous sections change header or footer clearance;
- [#84](https://github.com/nerdy-pro/dxpdf/issues/84) - implement line-aware `keepLines` and widow/orphan pagination;
- [#85](https://github.com/nerdy-pro/dxpdf/issues/85) - implement complete OpenType hybrid font resolution.
