### PR TITLE
Refactor font extraction and collection handling

### DIFF
--- a/src/render/fonts/mod.rs
+++ b/src/render/fonts/mod.rs
@@ -342,14 +342,12 @@ impl FontRegistry {
     /// ranking reads the font rather than the slot it was declared in. See
     /// [`Self::embedded_meta`].
     ///
-    /// **How many faces of a collection are actually reachable is
-    /// platform-dependent.** Skia's CoreText backend declines a non-zero
-    /// collection index outright — `new_from_data(bytes, 1)` returns `None` on
-    /// macOS — so a two-face collection contributes one face there and both on
-    /// a backend that honours the index. Faces the platform will not open are
-    /// skipped rather than registered as unopenable, and only a font that yields
-    /// *no* face at all is an error. The subsetting pass does not share this
-    /// limitation: it carves a face out of the collection's own bytes.
+    /// Every face of a collection is carved into a standalone SFNT
+    /// (`open_embedded_typeface`) before the font system ever sees it, so no
+    /// platform is asked to interpret a collection index directly — Skia's
+    /// CoreText backend declines any index but 0. Only a font that yields no
+    /// face at all — carving failed, or the platform declined even the
+    /// carved bytes — is an error.
     pub fn register_embedded(
         &mut self,
         family: &str,
@@ -374,10 +372,7 @@ impl FontRegistry {
         let id = EmbeddedFontId(self.embedded.len() as u32);
         let mut registered = 0;
         for collection_index in 0..face_count {
-            let Some(typeface) = self
-                .font_mgr
-                .new_from_data(&bytes, collection_index as usize)
-            else {
+            let Some(typeface) = self.open_embedded_typeface(&bytes, collection_index) else {
                 continue;
             };
             self.catalog
@@ -398,6 +393,36 @@ impl FontRegistry {
             id.0
         );
         Ok(id)
+    }
+
+    /// Open one face of embedded font bytes, carving a collection face into a
+    /// standalone SFNT first (issue #116) — no platform is ever asked to
+    /// interpret a non-zero collection index, which Skia's CoreText backend
+    /// declines outright (`new_from_data(bytes, 1)` returns `None` on macOS).
+    ///
+    /// Used both at registration, to catalogue every face, and at
+    /// [`Self::open_uncached`], to reopen a face resolution has already
+    /// selected — carving is cheap enough to redo (collections in DOCX are
+    /// rare and small) and keeps this the single place either call site
+    /// needs to know the CoreText limitation exists at all.
+    fn open_embedded_typeface(&self, bytes: &[u8], collection_index: u32) -> Option<Typeface> {
+        let face_count = match FontFormat::detect(bytes) {
+            Ok(FontFormat::Ttc { face_count }) => face_count,
+            _ => 1,
+        };
+        if face_count <= 1 {
+            return self.font_mgr.new_from_data(bytes, 0);
+        }
+        match opentype::carve_collection_face(bytes, collection_index, face_count) {
+            Ok(carved) => self.font_mgr.new_from_data(&carved.bytes, 0),
+            Err(err) => {
+                log::debug!(
+                    "[font] could not carve collection face {collection_index} of \
+                     {face_count} ({err})"
+                );
+                None
+            }
+        }
     }
 
     /// Bytes for a registered embedded font.
@@ -560,9 +585,7 @@ impl FontRegistry {
                 collection_index,
             } => {
                 let bytes = self.embedded_bytes(*font);
-                let typeface = self
-                    .font_mgr
-                    .new_from_data(bytes, *collection_index as usize)?;
+                let typeface = self.open_embedded_typeface(bytes, *collection_index)?;
                 (
                     typeface,
                     TypefaceOrigin::Embedded {
@@ -992,6 +1015,39 @@ pub(crate) mod tests {
             r.embedded_meta(id),
             ("ByteIdentityProbe", EmbeddedFontVariant::Regular)
         );
+    }
+
+    /// issue #116: on Skia's CoreText backend, `FontMgr::new_from_data`
+    /// declines any collection index but 0 — `register_embedded` must carve
+    /// each face into its own standalone SFNT rather than asking the
+    /// platform to open it by index, or the second face of a collection is
+    /// silently unreachable. This exercises both the catalog side
+    /// (`register_embedded` must catalog face 1, not just face 0) and the
+    /// reopen side (`resolve` must actually reopen face 1 for rendering,
+    /// through the crate-private `open`/`open_uncached`): a fix to only one
+    /// of the two would still fail this test.
+    #[test]
+    fn every_face_of_an_embedded_collection_registers() {
+        let mut r = FontRegistry::new(fmgr());
+        let id = r
+            .register_embedded(
+                "DxCollection",
+                EmbeddedFontVariant::Regular,
+                fixture_bytes("DxCollection.ttc"),
+            )
+            .expect("a two-face collection must register");
+
+        for (collection_index, family) in [(0u32, "Dx Collection One"), (1, "Dx Collection Two")] {
+            let resolved = r.resolve(&FaceRequest::plain(family));
+            assert_eq!(
+                resolved.origin,
+                TypefaceOrigin::Embedded {
+                    id,
+                    collection_index
+                },
+                "face {collection_index} ('{family}') must resolve to its own record"
+            );
+        }
     }
 
     /// An embedded font is indexed under the name the *document* declared as

--- a/src/render/fonts/opentype/collection.rs
+++ b/src/render/fonts/opentype/collection.rs
@@ -1,0 +1,231 @@
+//! Carve one face out of a TrueType/OpenType Collection into a standalone SFNT.
+//!
+//! A collection is a table directory per face over one shared pool of tables —
+//! several faces routinely point at the *same* `glyf`, differing only in
+//! `cmap` and `name`. Copying the tables a face's own directory names —
+//! rather than slicing a byte range — is what makes this correct: the
+//! selected face's tables are scattered through the file and are not
+//! contiguous.
+//!
+//! This lives here, not behind the `subset-fonts` feature, because it now has
+//! two callers with different lifetimes: [`crate::render::fonts::FontRegistry`]
+//! carves at registration (and again whenever a face is reopened) so no
+//! platform is ever asked to interpret a non-zero collection index — Skia's
+//! CoreText backend declines one outright — and subsetting still carves the
+//! selected face out of the original bytes before subsetting it. Same move as
+//! [`super::format`]'s `FontFormat::detect`, for the same reason (issue #116).
+
+use super::format::FontFormat;
+use super::sfnt::rebuild_sfnt;
+use super::SfntFlavor;
+
+/// SFNT bytes verified ready for further use — subsetting, or handing
+/// straight to `FontMgr::new_from_data` at index 0. The newtype prevents
+/// accidental mixing with the various wrapper formats.
+#[derive(Debug, Clone)]
+pub struct ExtractedSfnt {
+    pub bytes: Vec<u8>,
+    pub flavor: SfntFlavor,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CollectionCarveError {
+    #[error("collection has {face_count} face(s); index {index} is out of range")]
+    IndexOutOfRange { index: u32, face_count: u32 },
+    #[error("could not carve face {index} out of the collection: {reason}")]
+    FaceUnreadable { index: u32, reason: String },
+}
+
+/// Resolve one face of a collection into a standalone SFNT.
+///
+/// The collection header is a `numFonts`-long array of offsets, each to an
+/// ordinary table directory. Copying the tables that directory names — rather
+/// than slicing a byte range — is what makes this correct: faces share table
+/// data, so the selected face's tables are scattered through the file and are
+/// not contiguous.
+pub fn carve_collection_face(
+    bytes: &[u8],
+    index: u32,
+    face_count: u32,
+) -> Result<ExtractedSfnt, CollectionCarveError> {
+    if index >= face_count {
+        return Err(CollectionCarveError::IndexOutOfRange { index, face_count });
+    }
+    let fail = |reason: String| CollectionCarveError::FaceUnreadable { index, reason };
+
+    // TTC header: 'ttcf', major u16, minor u16, numFonts u32, then numFonts × Offset32.
+    let offset_pos = TTC_HEADER_SIZE + index as usize * 4;
+    let directory = read_u32(bytes, offset_pos)
+        .ok_or_else(|| fail("collection offset table is truncated".into()))?
+        as usize;
+
+    let version = bytes
+        .get(directory..directory + 4)
+        .ok_or_else(|| fail("face directory is past the end of the file".into()))?;
+    let flavor = match FontFormat::detect(version) {
+        Ok(FontFormat::Sfnt(flavor)) => flavor,
+        Ok(other) => return Err(fail(format!("face directory is not an SFNT ({other:?})"))),
+        Err(err) => return Err(fail(err.to_string())),
+    };
+
+    let num_tables = read_u16(bytes, directory + 4)
+        .ok_or_else(|| fail("face directory header is truncated".into()))?
+        as usize;
+    let mut tables = Vec::with_capacity(num_tables);
+    for i in 0..num_tables {
+        let rec = directory + SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+        let tag = bytes
+            .get(rec..rec + 4)
+            .ok_or_else(|| fail(format!("table record {i} is truncated")))?;
+        let offset = read_u32(bytes, rec + 8)
+            .ok_or_else(|| fail(format!("table record {i} has no offset")))?
+            as usize;
+        let length = read_u32(bytes, rec + 12)
+            .ok_or_else(|| fail(format!("table record {i} has no length")))?
+            as usize;
+        let data = offset
+            .checked_add(length)
+            .and_then(|end| bytes.get(offset..end))
+            .ok_or_else(|| fail(format!("table {i} runs past the end of the file")))?;
+        let mut t = [0u8; 4];
+        t.copy_from_slice(tag);
+        tables.push((t, data.to_vec()));
+    }
+
+    let rebuilt = rebuild_sfnt(version, tables).map_err(fail)?;
+    log::debug!(
+        "[font] carved face {index} of {face_count} out of a collection \
+         ({} bytes → {} bytes)",
+        bytes.len(),
+        rebuilt.len()
+    );
+    Ok(ExtractedSfnt {
+        bytes: rebuilt,
+        flavor,
+    })
+}
+
+const TTC_HEADER_SIZE: usize = 12;
+const SFNT_HEADER_SIZE: usize = 12;
+const TABLE_RECORD_SIZE: usize = 16;
+
+fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    let end = offset.checked_add(2)?;
+    let slice = bytes.get(offset..end)?;
+    Some(u16::from_be_bytes([slice[0], slice[1]]))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    let end = offset.checked_add(4)?;
+    let slice = bytes.get(offset..end)?;
+    Some(u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::fonts::tests::arbitrary_system_font_bytes;
+
+    /// Build a two-face collection whose faces share every table but `name`,
+    /// which is how real collections are laid out — and the reason a face
+    /// cannot be extracted by slicing a byte range.
+    fn collection_of_two(sfnt: &[u8]) -> Vec<u8> {
+        let num_tables = u16::from_be_bytes([sfnt[4], sfnt[5]]) as usize;
+        let mut tables = Vec::new();
+        for i in 0..num_tables {
+            let rec = 12 + i * 16;
+            let mut tag = [0u8; 4];
+            tag.copy_from_slice(&sfnt[rec..rec + 4]);
+            let off = u32::from_be_bytes(sfnt[rec + 8..rec + 12].try_into().unwrap()) as usize;
+            let len = u32::from_be_bytes(sfnt[rec + 12..rec + 16].try_into().unwrap()) as usize;
+            tables.push((tag, sfnt[off..off + len].to_vec()));
+        }
+
+        // Two identical directories over one shared table pool.
+        let header = 12 + 2 * 4;
+        let dir_size = 12 + num_tables * 16;
+        let pool_start = header + 2 * dir_size;
+
+        let mut pool = Vec::new();
+        let mut offsets = Vec::new();
+        for (_, data) in &tables {
+            offsets.push(pool_start + pool.len());
+            pool.extend_from_slice(data);
+            while !pool.len().is_multiple_of(4) {
+                pool.push(0);
+            }
+        }
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"ttcf");
+        out.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
+        out.extend_from_slice(&2u32.to_be_bytes());
+        out.extend_from_slice(&(header as u32).to_be_bytes());
+        out.extend_from_slice(&((header + dir_size) as u32).to_be_bytes());
+        for _ in 0..2 {
+            out.extend_from_slice(&sfnt[0..4]);
+            out.extend_from_slice(&sfnt[4..12]);
+            for (i, (tag, data)) in tables.iter().enumerate() {
+                out.extend_from_slice(tag);
+                out.extend_from_slice(&[0u8; 4]); // checksum — rebuilt on carve
+                out.extend_from_slice(&(offsets[i] as u32).to_be_bytes());
+                out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+            }
+        }
+        out.extend_from_slice(&pool);
+        out
+    }
+
+    /// A collection face is carved into a standalone SFNT rather than refused.
+    /// Skia accepting the result is the real assertion: it means the rebuilt
+    /// directory, checksums and `head.checksumAdjustment` are all right.
+    #[test]
+    fn a_collection_face_is_carved_into_a_standalone_font() {
+        let sfnt = arbitrary_system_font_bytes();
+        let ttc = collection_of_two(&sfnt);
+        assert!(matches!(
+            FontFormat::detect(&ttc),
+            Ok(FontFormat::Ttc { face_count: 2 })
+        ));
+
+        for index in 0..2 {
+            let carved = carve_collection_face(&ttc, index, 2)
+                .unwrap_or_else(|e| panic!("face {index} must carve: {e}"));
+            assert!(matches!(
+                FontFormat::detect(&carved.bytes),
+                Ok(FontFormat::Sfnt(_))
+            ));
+            assert!(
+                skia_safe::FontMgr::new()
+                    .new_from_data(&carved.bytes[..], 0)
+                    .is_some(),
+                "Skia must accept the carved face {index}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_collection_index_past_the_end_is_reported() {
+        let ttc = collection_of_two(&arbitrary_system_font_bytes());
+        assert!(matches!(
+            carve_collection_face(&ttc, 7, 2),
+            Err(CollectionCarveError::IndexOutOfRange {
+                index: 7,
+                face_count: 2
+            })
+        ));
+    }
+
+    /// A header that promises faces it does not describe must produce a typed
+    /// error, not a panic — these bytes come from documents.
+    #[test]
+    fn a_truncated_collection_is_reported_not_fatal() {
+        let mut ttc = b"ttcf".to_vec();
+        ttc.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
+        ttc.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // numFonts = 2, no offsets
+        assert!(matches!(
+            carve_collection_face(&ttc, 0, 2),
+            Err(CollectionCarveError::FaceUnreadable { index: 0, .. })
+        ));
+    }
+}

--- a/src/render/fonts/opentype/mod.rs
+++ b/src/render/fonts/opentype/mod.rs
@@ -31,13 +31,22 @@
 //! yields a typed error that the catalogue records and moves past. The `name`
 //! table of a real shipping font is routinely a little malformed, so this is
 //! the common path, not the exceptional one.
+//!
+//! **Also assembles, not just reads.** [`collection::carve_collection_face`]
+//! and `sfnt::rebuild_sfnt` build standalone SFNT bytes from a table list —
+//! the write-side counterpart to the read-only table parsers above, needed
+//! because a TrueType Collection's faces are not independently addressable
+//! (by any platform, in `FontMgr::new_from_data`'s case) without it.
 
+pub mod collection;
 pub mod format;
 pub mod fvar;
 pub mod name;
 pub mod os2;
+pub mod sfnt;
 pub mod stat;
 
+pub use collection::{carve_collection_face, CollectionCarveError, ExtractedSfnt};
 pub use format::{FontFormat, FormatError, SfntFlavor, WoffVersion};
 pub use fvar::{Axis, AxisTag, NamedInstance, VariationCoord};
 pub use name::{NameId, NameRecords, PlatformId};

--- a/src/render/fonts/opentype/sfnt.rs
+++ b/src/render/fonts/opentype/sfnt.rs
@@ -1,0 +1,370 @@
+//! Assemble an SFNT from a table list — table directory, §5.2 ordering,
+//! per-table checksums, `head.checksumAdjustment`.
+//!
+//! Lives here rather than behind `subset-fonts` because it has two callers
+//! now: [`super::collection::carve_collection_face`], needed unconditionally
+//! so `FontRegistry` never asks a platform to open a non-zero collection
+//! index, and `subset::name_splice::replace_table`, which splices the
+//! original `name` table back into a subsetted font. Same move as
+//! [`super::format`]'s `FontFormat::detect` — see the module doc.
+
+const HEAD_TAG: &[u8; 4] = b"head";
+const SFNT_HEADER_SIZE: usize = 12;
+const TABLE_RECORD_SIZE: usize = 16;
+const HEAD_CHECKSUM_ADJUSTMENT_OFFSET: usize = 8;
+const HEAD_MAGIC: u32 = 0xB1B0_AFBA;
+
+/// Largest table count whose directory search fields are expressible.
+///
+/// OpenType §5.2 defines `searchRange = 2^floor(log2(numTables)) * 16` as a
+/// `uint16`. At 4096 tables that is 65 536 — one past the field's range — and
+/// `rangeShift = numTables * 16 - searchRange` goes with it. The format cannot
+/// describe such a directory at all, so `rebuild_sfnt` declines rather than
+/// writing wrapped values. Real fonts carry on the order of ten tables.
+const MAX_TABLES: usize = 4095;
+
+/// Assemble an SFNT from `tables`. Takes ownership so it can enforce the
+/// ascending-tag order OpenType §5.2 requires of the table directory — the sort
+/// used to sit in `replace_table`, which left this function silently producing
+/// an invalid directory for any other caller.
+pub(crate) fn rebuild_sfnt(
+    version: &[u8],
+    mut tables: Vec<([u8; 4], Vec<u8>)>,
+) -> Result<Vec<u8>, String> {
+    // Both bounds below used to be handled inline and neither worked. An empty
+    // set took an `if n == 0` branch that set `entry_selector = 0` and then
+    // underflowed on `range_shift = 0*16 - 16`; a large set overflowed
+    // `search_range` in `u16`. Both panicked in debug and wrapped in release.
+    // Returning `Err` instead feeds the caller's existing best-effort path —
+    // `apply.rs` falls back to the unnamed subset rather than aborting.
+    if tables.is_empty() {
+        return Err("cannot build an SFNT with no tables".into());
+    }
+    if tables.len() > MAX_TABLES {
+        return Err(format!(
+            "{} tables exceeds the {MAX_TABLES} a table directory can describe",
+            tables.len()
+        ));
+    }
+    let n = tables.len() as u16;
+    // §5.2: the directory is sorted by tag.
+    tables.sort_by_key(|t| t.0);
+
+    // OpenType §5.2: entrySelector = floor(log2(numTables));
+    // searchRange = 2^entrySelector * 16; rangeShift = numTables*16 - searchRange.
+    // `n >= 1` is guaranteed above, so `leading_zeros() <= 15` and the
+    // subtraction cannot underflow.
+    let entry_selector = 15 - n.leading_zeros() as u16;
+    let search_range = (1u16 << entry_selector) * 16;
+    let range_shift = n * 16 - search_range;
+
+    let dir_size = SFNT_HEADER_SIZE + tables.len() * TABLE_RECORD_SIZE;
+    let mut offsets = Vec::with_capacity(tables.len());
+    let mut cur = dir_size;
+    for (_, data) in &tables {
+        offsets.push(cur);
+        cur += data.len();
+        cur = (cur + 3) & !3; // 4-byte alignment between tables
+    }
+    let total_size = cur;
+
+    let mut out = vec![0u8; total_size];
+    out[0..4].copy_from_slice(version);
+    out[4..6].copy_from_slice(&n.to_be_bytes());
+    out[6..8].copy_from_slice(&search_range.to_be_bytes());
+    out[8..10].copy_from_slice(&entry_selector.to_be_bytes());
+    out[10..12].copy_from_slice(&range_shift.to_be_bytes());
+
+    for (i, ((t, data), &off)) in tables.iter().zip(offsets.iter()).enumerate() {
+        let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+        out[rec..rec + 4].copy_from_slice(t);
+        // checksum filled below
+        out[rec + 8..rec + 12].copy_from_slice(&(off as u32).to_be_bytes());
+        out[rec + 12..rec + 16].copy_from_slice(&(data.len() as u32).to_be_bytes());
+        out[off..off + data.len()].copy_from_slice(data);
+    }
+
+    // §5.2: `head.checksumAdjustment` must read zero for *both* checksums that
+    // cover it — the `head` table's own directory entry and the whole-file
+    // total. Zero it before the loop below, not after: computing the table
+    // checksums first and then changing the field leaves the stored `head`
+    // checksum describing bytes that no longer exist. The whole-file invariant
+    // held either way, which is why nothing downstream noticed.
+    let head_adj_pos = match tables.iter().position(|(t, _)| t == HEAD_TAG) {
+        Some(i) => {
+            // A `head` too short to contain the field would otherwise have its
+            // "adjustment" written into padding or the following table.
+            if tables[i].1.len() < HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4 {
+                return Err("head table too short for checksumAdjustment".into());
+            }
+            let pos = offsets[i] + HEAD_CHECKSUM_ADJUSTMENT_OFFSET;
+            out[pos..pos + 4].copy_from_slice(&0u32.to_be_bytes());
+            Some(pos)
+        }
+        None => None,
+    };
+
+    // Per-table checksums are computed over the padded table region.
+    for (i, ((_, data), &off)) in tables.iter().zip(offsets.iter()).enumerate() {
+        let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+        let padded_len = (data.len() + 3) & !3;
+        let checksum = sfnt_checksum(&out[off..off + padded_len]);
+        out[rec + 4..rec + 8].copy_from_slice(&checksum.to_be_bytes());
+    }
+
+    // §5.2: head.checksumAdjustment = 0xB1B0AFBA - whole-file checksum, taken
+    // with every directory entry final and the field itself still zero. Writing
+    // it is the last mutation, so the file then sums to the magic exactly.
+    if let Some(pos) = head_adj_pos {
+        let total = sfnt_checksum(&out);
+        let adjustment = HEAD_MAGIC.wrapping_sub(total);
+        out[pos..pos + 4].copy_from_slice(&adjustment.to_be_bytes());
+    }
+
+    Ok(out)
+}
+
+/// Sum the buffer as big-endian u32 values, with zero-padding at the tail
+/// if the length isn't 4-aligned.
+fn sfnt_checksum(data: &[u8]) -> u32 {
+    let mut sum: u32 = 0;
+    let chunks = data.chunks_exact(4);
+    let rem = chunks.remainder();
+    for c in chunks {
+        sum = sum.wrapping_add(u32::from_be_bytes([c[0], c[1], c[2], c[3]]));
+    }
+    if !rem.is_empty() {
+        let mut padded = [0u8; 4];
+        padded[..rem.len()].copy_from_slice(rem);
+        sum = sum.wrapping_add(u32::from_be_bytes(padded));
+    }
+    sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_u32(buf: &[u8], offset: usize) -> u32 {
+        u32::from_be_bytes([
+            buf[offset],
+            buf[offset + 1],
+            buf[offset + 2],
+            buf[offset + 3],
+        ])
+    }
+
+    // ── `rebuild_sfnt` directory fields ──────────────────────────────────
+
+    fn tbl(tag: &[u8; 4], len: usize) -> ([u8; 4], Vec<u8>) {
+        (*tag, vec![0u8; len])
+    }
+
+    /// Synthetic table sets of arbitrary size, for the boundary cases.
+    fn many(n: usize) -> Vec<([u8; 4], Vec<u8>)> {
+        (0..n)
+            .map(|i| {
+                let mut t = [0u8; 4];
+                t.copy_from_slice(&format!("{i:04x}").as_bytes()[..4]);
+                (t, vec![0u8; 4])
+            })
+            .collect()
+    }
+
+    fn dir_fields(sfnt: &[u8]) -> (u16, u16, u16, u16) {
+        let g = |o: usize| u16::from_be_bytes([sfnt[o], sfnt[o + 1]]);
+        (g(4), g(6), g(8), g(10)) // numTables, searchRange, entrySelector, rangeShift
+    }
+
+    /// OpenType §5.2's own formulas, spelled out independently of the
+    /// implementation so the test cannot inherit its arithmetic.
+    #[test]
+    fn directory_search_fields_follow_the_spec_formulas() {
+        for n in [1usize, 2, 3, 4, 7, 8, 15, 16, 17, 100, 4095] {
+            let out = rebuild_sfnt(b"\x00\x01\x00\x00", many(n)).expect("n={n}");
+            let (num, search_range, entry_selector, range_shift) = dir_fields(&out);
+            let expected_sel = (usize::BITS - 1 - n.leading_zeros()) as u16; // floor(log2 n)
+            let expected_range = (1u32 << expected_sel) * 16;
+            assert_eq!(num as usize, n, "numTables for n={n}");
+            assert_eq!(entry_selector, expected_sel, "entrySelector for n={n}");
+            assert_eq!(search_range as u32, expected_range, "searchRange for n={n}");
+            assert_eq!(
+                range_shift as u32,
+                n as u32 * 16 - expected_range,
+                "rangeShift for n={n}"
+            );
+        }
+    }
+
+    /// 4096 is where `searchRange` would be 65 536 — one past `uint16`. The
+    /// old code panicked here in debug and wrapped in release; it now declines,
+    /// and 4095 still succeeds so the bound is exact rather than conservative.
+    #[test]
+    fn the_table_count_bound_is_exact() {
+        assert!(
+            rebuild_sfnt(b"\x00\x01\x00\x00", many(MAX_TABLES)).is_ok(),
+            "{MAX_TABLES} tables must still build"
+        );
+        let err = rebuild_sfnt(b"\x00\x01\x00\x00", many(MAX_TABLES + 1))
+            .expect_err("one past the bound must be declined, not wrapped");
+        assert!(err.contains("exceeds"), "got: {err}");
+    }
+
+    /// The empty set took a guard that set `entry_selector = 0` and then
+    /// underflowed computing `rangeShift`. Unreachable from `replace_table`,
+    /// which always pushes at least one table — but the function is callable
+    /// on its own, and a guard that panics is not a guard.
+    #[test]
+    fn an_empty_table_set_is_declined_not_underflowed() {
+        let err = rebuild_sfnt(b"\x00\x01\x00\x00", Vec::new()).expect_err("must decline");
+        assert!(err.contains("no tables"), "got: {err}");
+    }
+
+    /// Tables are laid out in tag order with 4-byte alignment between them,
+    /// and every directory entry must point at its own data.
+    #[test]
+    fn tables_are_sorted_by_tag_and_four_byte_aligned() {
+        // Deliberately out of order, with a length that forces padding.
+        let tables = vec![tbl(b"zzzz", 5), tbl(b"aaaa", 3), tbl(b"mmmm", 4)];
+        let out = rebuild_sfnt(b"\x00\x01\x00\x00", tables.clone()).expect("build");
+        let n = u16::from_be_bytes([out[4], out[5]]) as usize;
+        assert_eq!(n, 3);
+
+        let mut seen = Vec::new();
+        for i in 0..n {
+            let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+            let tag = &out[rec..rec + 4];
+            let off = read_u32(&out, rec + 8) as usize;
+            let len = read_u32(&out, rec + 12) as usize;
+            assert_eq!(off % 4, 0, "table {i} is not 4-byte aligned");
+            assert!(off + len <= out.len(), "table {i} runs past the buffer");
+            seen.push(tag.to_vec());
+            // The recorded length is the *unpadded* one.
+            let expected = tables.iter().find(|(t, _)| t == tag).expect("known tag");
+            assert_eq!(len, expected.1.len(), "length for {:?}", tag);
+        }
+        let mut sorted = seen.clone();
+        sorted.sort();
+        assert_eq!(seen, sorted, "directory must be sorted by tag");
+    }
+
+    // ── OpenType §5.2 checksums ──────────────────────────────────────────
+
+    /// Recompute a table's directory checksum the way a validator would.
+    fn stored_and_actual(sfnt: &[u8], tag: &[u8; 4]) -> Option<(u32, u32)> {
+        let n = u16::from_be_bytes([sfnt[4], sfnt[5]]) as usize;
+        (0..n).find_map(|i| {
+            let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+            (&sfnt[rec..rec + 4] == tag).then(|| {
+                let stored = read_u32(sfnt, rec + 4);
+                let off = read_u32(sfnt, rec + 8) as usize;
+                let len = read_u32(sfnt, rec + 12) as usize;
+                let padded = (len + 3) & !3;
+                (stored, sfnt_checksum(&sfnt[off..off + padded]))
+            })
+        })
+    }
+
+    /// §5.2: the whole font, summed as big-endian `u32`s with
+    /// `checksumAdjustment` in place, must equal `0xB1B0AFBA`.
+    #[test]
+    fn the_whole_file_sums_to_the_head_magic() {
+        let mut head = vec![0u8; 54];
+        head[8..12].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
+        let out = rebuild_sfnt(
+            b"\x00\x01\x00\x00",
+            vec![(*b"head", head), (*b"name", vec![1, 2, 3, 4, 5])],
+        )
+        .expect("build");
+        assert_eq!(sfnt_checksum(&out), HEAD_MAGIC);
+    }
+
+    /// §5.2: `head`'s *directory* checksum is the one taken with
+    /// `checksumAdjustment` zeroed.
+    ///
+    /// Previously the per-table loop ran first and the field was rewritten
+    /// afterwards, so the stored value described bytes that no longer existed —
+    /// it came out as the caller's incoming garbage (`0xdeadbeef` here) rather
+    /// than the spec's value. The whole-file invariant above still held, which
+    /// is exactly why this went unnoticed.
+    #[test]
+    fn head_directory_checksum_is_taken_with_the_adjustment_zeroed() {
+        let mut head = vec![0u8; 54];
+        head[8..12].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
+        let out = rebuild_sfnt(
+            b"\x00\x01\x00\x00",
+            vec![(*b"head", head), (*b"name", vec![9, 9, 9, 9])],
+        )
+        .expect("build");
+
+        let (stored, _) = stored_and_actual(&out, HEAD_TAG).expect("head present");
+        // Reconstruct the spec value: head's bytes with the field zeroed.
+        let n = u16::from_be_bytes([out[4], out[5]]) as usize;
+        let (off, len) = (0..n)
+            .find_map(|i| {
+                let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
+                (&out[rec..rec + 4] == HEAD_TAG).then(|| {
+                    (
+                        read_u32(&out, rec + 8) as usize,
+                        read_u32(&out, rec + 12) as usize,
+                    )
+                })
+            })
+            .expect("head record");
+        let mut zeroed = out[off..off + ((len + 3) & !3)].to_vec();
+        zeroed[HEAD_CHECKSUM_ADJUSTMENT_OFFSET..HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4]
+            .copy_from_slice(&0u32.to_be_bytes());
+
+        assert_eq!(stored, sfnt_checksum(&zeroed), "§5.2 head checksum");
+        assert_ne!(
+            stored, 0xDEAD_BEEF,
+            "must not be the caller's incoming adjustment"
+        );
+    }
+
+    /// Every non-`head` table's stored checksum must match its bytes exactly —
+    /// nothing rewrites those after the loop.
+    #[test]
+    fn non_head_directory_checksums_match_their_bytes() {
+        let out = rebuild_sfnt(
+            b"\x00\x01\x00\x00",
+            vec![
+                (*b"head", vec![0u8; 54]),
+                (*b"name", vec![7; 13]),
+                (*b"cmap", vec![3; 8]),
+            ],
+        )
+        .expect("build");
+        for tag in [b"name", b"cmap"] {
+            let (stored, actual) = stored_and_actual(&out, tag).expect("table present");
+            assert_eq!(
+                stored,
+                actual,
+                "checksum for {:?}",
+                std::str::from_utf8(tag)
+            );
+        }
+    }
+
+    /// A font with no `head` still builds — the adjustment step is simply
+    /// skipped, and no whole-file invariant applies without the field.
+    #[test]
+    fn a_font_without_head_still_builds() {
+        let out = rebuild_sfnt(b"\x00\x01\x00\x00", vec![(*b"name", vec![1, 2, 3, 4])])
+            .expect("build without head");
+        let (stored, actual) = stored_and_actual(&out, b"name").expect("name present");
+        assert_eq!(stored, actual);
+    }
+
+    /// A `head` too short to hold `checksumAdjustment` is declined. Writing at
+    /// its nominal offset would have landed in padding or the next table.
+    #[test]
+    fn a_truncated_head_is_declined_not_written_past() {
+        let err = rebuild_sfnt(
+            b"\x00\x01\x00\x00",
+            vec![(*b"head", vec![0u8; 8]), (*b"name", vec![1, 2, 3, 4])],
+        )
+        .expect_err("must decline");
+        assert!(err.contains("head table too short"), "got: {err}");
+    }
+}

--- a/src/render/subset/extract.rs
+++ b/src/render/subset/extract.rs
@@ -8,33 +8,16 @@
 //!    reports which face of a collection the typeface came from.
 //! 2. Classify with [`FontFormat::detect`].
 //! 3. Direct SFNT → return as-is. WOFF2 → decompress via `fontcull`. TTC →
-//!    carve out the selected face. WOFF1 → return
+//!    carve out the selected face via [`carve_collection_face`] — which face
+//!    is "selected" travels on [`TypefaceOrigin::Embedded::collection_index`].
+//!    WOFF1 → return
 //!    [`ExtractionError::UnsupportedFormat`], a documented capability boundary:
 //!    ECMA-376 forbids WOFF in DOCX.
-//!
-//! # Collections
-//!
-//! A TrueType Collection is a table directory per face over one shared pool of
-//! tables — several faces routinely point at the *same* `glyf`, differing only
-//! in `cmap` and `name`. `fontcull` takes a single-face SFNT, so the selected
-//! face's directory is resolved into a standalone font whose tables are copies
-//! of the ones it referenced.
-//!
-//! Which face is "selected" is not something OOXML can say: `fontTable.xml`
-//! offers four style slots per `w:font/@w:name` and no index. It comes from the
-//! catalogue, which enumerated the collection when the font was registered, and
-//! travels on [`TypefaceOrigin::Embedded::collection_index`].
 
-use crate::render::fonts::opentype::{FontFormat, FormatError, SfntFlavor};
+use crate::render::fonts::opentype::{
+    carve_collection_face, CollectionCarveError, ExtractedSfnt, FontFormat, FormatError,
+};
 use crate::render::fonts::{FontRegistry, TypefaceEntry, TypefaceOrigin};
-
-/// SFNT bytes verified ready for `fontcull::subset_font_data_unicode`. The
-/// newtype prevents accidental mixing with the various wrapper formats.
-#[derive(Debug, Clone)]
-pub struct ExtractedSfnt {
-    pub bytes: Vec<u8>,
-    pub flavor: SfntFlavor,
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractionError {
@@ -48,10 +31,8 @@ pub enum ExtractionError {
     Woff2DecompressionFailed(String),
     #[error("post-decompression bytes are not SFNT (got {0:?})")]
     PostUnwrapNotSfnt(FontFormat),
-    #[error("collection has {face_count} face(s); index {index} is out of range")]
-    CollectionIndexOutOfRange { index: u32, face_count: u32 },
-    #[error("could not carve face {index} out of the collection: {reason}")]
-    CollectionFaceUnreadable { index: u32, reason: String },
+    #[error(transparent)]
+    Collection(#[from] CollectionCarveError),
 }
 
 /// Pull SFNT bytes for a typeface, unwrapping WOFF2 if necessary.
@@ -84,98 +65,13 @@ fn classify_and_unwrap(bytes: Vec<u8>, face: u32) -> Result<ExtractedSfnt, Extra
     let format = FontFormat::detect(&bytes)?;
     match format {
         FontFormat::Sfnt(flavor) => Ok(ExtractedSfnt { bytes, flavor }),
-        FontFormat::Ttc { face_count } => carve_collection_face(&bytes, face, face_count),
+        FontFormat::Ttc { face_count } => Ok(carve_collection_face(&bytes, face, face_count)?),
         FontFormat::Woff(crate::render::subset::WoffVersion::V2) => unwrap_woff2(&bytes),
         // WOFF1 is a documented capability boundary — see the module doc.
         FontFormat::Woff(crate::render::subset::WoffVersion::V1) => {
             Err(ExtractionError::UnsupportedFormat(format))
         }
     }
-}
-
-/// Resolve one face of a collection into a standalone SFNT.
-///
-/// The collection header is a `numFonts`-long array of offsets, each to an
-/// ordinary table directory. Copying the tables that directory names — rather
-/// than slicing a byte range — is what makes this correct: faces share table
-/// data, so the selected face's tables are scattered through the file and are
-/// not contiguous.
-fn carve_collection_face(
-    bytes: &[u8],
-    index: u32,
-    face_count: u32,
-) -> Result<ExtractedSfnt, ExtractionError> {
-    if index >= face_count {
-        return Err(ExtractionError::CollectionIndexOutOfRange { index, face_count });
-    }
-    let fail = |reason: String| ExtractionError::CollectionFaceUnreadable { index, reason };
-
-    // TTC header: 'ttcf', major u16, minor u16, numFonts u32, then numFonts × Offset32.
-    let offset_pos = TTC_HEADER_SIZE + index as usize * 4;
-    let directory = read_u32(bytes, offset_pos)
-        .ok_or_else(|| fail("collection offset table is truncated".into()))?
-        as usize;
-
-    let version = bytes
-        .get(directory..directory + 4)
-        .ok_or_else(|| fail("face directory is past the end of the file".into()))?;
-    let flavor = match FontFormat::detect(version) {
-        Ok(FontFormat::Sfnt(flavor)) => flavor,
-        Ok(other) => return Err(fail(format!("face directory is not an SFNT ({other:?})"))),
-        Err(err) => return Err(fail(err.to_string())),
-    };
-
-    let num_tables = read_u16(bytes, directory + 4)
-        .ok_or_else(|| fail("face directory header is truncated".into()))?
-        as usize;
-    let mut tables = Vec::with_capacity(num_tables);
-    for i in 0..num_tables {
-        let rec = directory + SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-        let tag = bytes
-            .get(rec..rec + 4)
-            .ok_or_else(|| fail(format!("table record {i} is truncated")))?;
-        let offset = read_u32(bytes, rec + 8)
-            .ok_or_else(|| fail(format!("table record {i} has no offset")))?
-            as usize;
-        let length = read_u32(bytes, rec + 12)
-            .ok_or_else(|| fail(format!("table record {i} has no length")))?
-            as usize;
-        let data = offset
-            .checked_add(length)
-            .and_then(|end| bytes.get(offset..end))
-            .ok_or_else(|| fail(format!("table {i} runs past the end of the file")))?;
-        let mut t = [0u8; 4];
-        t.copy_from_slice(tag);
-        tables.push((t, data.to_vec()));
-    }
-
-    let rebuilt = super::name_splice::rebuild_sfnt(version, tables).map_err(fail)?;
-    log::debug!(
-        "[subset] carved face {index} of {face_count} out of a collection \
-         ({} bytes → {} bytes)",
-        bytes.len(),
-        rebuilt.len()
-    );
-    Ok(ExtractedSfnt {
-        bytes: rebuilt,
-        flavor,
-    })
-}
-
-const TTC_HEADER_SIZE: usize = 12;
-const SFNT_HEADER_SIZE: usize = 12;
-const TABLE_RECORD_SIZE: usize = 16;
-
-fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
-    let end = offset.checked_add(2)?;
-    let slice = bytes.get(offset..end)?;
-    Some(u16::from_be_bytes([slice[0], slice[1]]))
-}
-
-fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
-    let end = offset.checked_add(4)?;
-    let slice = bytes.get(offset..end)?;
-    Some(u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]))
 }
 
 fn unwrap_woff2(bytes: &[u8]) -> Result<ExtractedSfnt, ExtractionError> {
@@ -195,6 +91,7 @@ fn unwrap_woff2(bytes: &[u8]) -> Result<ExtractedSfnt, ExtractionError> {
 mod tests {
     use super::*;
     use crate::model::EmbeddedFontVariant;
+    use crate::render::fonts::opentype::SfntFlavor;
     use crate::render::fonts::FaceRequest;
     use crate::render::fonts::FontRegistry;
     use crate::render::subset::WoffVersion;
@@ -262,93 +159,24 @@ mod tests {
         ));
     }
 
-    /// Build a two-face collection whose faces share every table but `name`,
-    /// which is how real collections are laid out — and the reason a face
-    /// cannot be extracted by slicing a byte range.
-    fn collection_of_two(sfnt: &[u8]) -> Vec<u8> {
-        let num_tables = u16::from_be_bytes([sfnt[4], sfnt[5]]) as usize;
-        let mut tables = Vec::new();
-        for i in 0..num_tables {
-            let rec = 12 + i * 16;
-            let mut tag = [0u8; 4];
-            tag.copy_from_slice(&sfnt[rec..rec + 4]);
-            let off = u32::from_be_bytes(sfnt[rec + 8..rec + 12].try_into().unwrap()) as usize;
-            let len = u32::from_be_bytes(sfnt[rec + 12..rec + 16].try_into().unwrap()) as usize;
-            tables.push((tag, sfnt[off..off + len].to_vec()));
-        }
-
-        // Two identical directories over one shared table pool.
-        let header = 12 + 2 * 4;
-        let dir_size = 12 + num_tables * 16;
-        let pool_start = header + 2 * dir_size;
-
-        let mut pool = Vec::new();
-        let mut offsets = Vec::new();
-        for (_, data) in &tables {
-            offsets.push(pool_start + pool.len());
-            pool.extend_from_slice(data);
-            while !pool.len().is_multiple_of(4) {
-                pool.push(0);
-            }
-        }
-
-        let mut out = Vec::new();
-        out.extend_from_slice(b"ttcf");
-        out.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
-        out.extend_from_slice(&2u32.to_be_bytes());
-        out.extend_from_slice(&(header as u32).to_be_bytes());
-        out.extend_from_slice(&((header + dir_size) as u32).to_be_bytes());
-        for _ in 0..2 {
-            out.extend_from_slice(&sfnt[0..4]);
-            out.extend_from_slice(&sfnt[4..12]);
-            for (i, (tag, data)) in tables.iter().enumerate() {
-                out.extend_from_slice(tag);
-                out.extend_from_slice(&[0u8; 4]); // checksum — rebuilt on carve
-                out.extend_from_slice(&(offsets[i] as u32).to_be_bytes());
-                out.extend_from_slice(&(data.len() as u32).to_be_bytes());
-            }
-        }
-        out.extend_from_slice(&pool);
-        out
-    }
-
-    /// A collection face is carved into a standalone SFNT rather than refused.
-    /// Skia accepting the result is the real assertion: it means the rebuilt
-    /// directory, checksums and `head.checksumAdjustment` are all right.
-    #[test]
-    fn a_collection_face_is_carved_into_a_standalone_font() {
-        let sfnt = arbitrary_system_font_bytes();
-        let ttc = collection_of_two(&sfnt);
-        assert!(matches!(
-            FontFormat::detect(&ttc),
-            Ok(FontFormat::Ttc { face_count: 2 })
-        ));
-
-        for index in 0..2 {
-            let carved = classify_and_unwrap(ttc.clone(), index)
-                .unwrap_or_else(|e| panic!("face {index} must carve: {e}"));
-            assert!(matches!(
-                FontFormat::detect(&carved.bytes),
-                Ok(FontFormat::Sfnt(_))
-            ));
-            assert!(
-                skia_safe::FontMgr::new()
-                    .new_from_data(&carved.bytes[..], 0)
-                    .is_some(),
-                "Skia must accept the carved face {index}"
-            );
-        }
-    }
+    // Collection carving itself (`carve_collection_face`) is unit-tested at
+    // its own definition (`fonts::opentype::collection`) — these two tests
+    // only need to pin that `classify_and_unwrap` routes a `Ttc` to it and
+    // surfaces its error through `ExtractionError::Collection` correctly.
 
     #[test]
     fn a_collection_index_past_the_end_is_reported() {
-        let ttc = collection_of_two(&arbitrary_system_font_bytes());
+        let mut ttc = b"ttcf".to_vec();
+        ttc.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
+        ttc.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // numFonts = 2
         assert!(matches!(
             classify_and_unwrap(ttc, 7),
-            Err(ExtractionError::CollectionIndexOutOfRange {
-                index: 7,
-                face_count: 2
-            })
+            Err(ExtractionError::Collection(
+                CollectionCarveError::IndexOutOfRange {
+                    index: 7,
+                    face_count: 2
+                }
+            ))
         ));
     }
 
@@ -361,7 +189,9 @@ mod tests {
         ttc.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // numFonts = 2, no offsets
         assert!(matches!(
             classify_and_unwrap(ttc, 0),
-            Err(ExtractionError::CollectionFaceUnreadable { index: 0, .. })
+            Err(ExtractionError::Collection(
+                CollectionCarveError::FaceUnreadable { index: 0, .. }
+            ))
         ));
     }
 

--- a/src/render/subset/mod.rs
+++ b/src/render/subset/mod.rs
@@ -33,12 +33,16 @@ pub mod collect;
 pub mod extract;
 pub mod name_splice;
 
-/// Font-format detection lives with the other OpenType readers in
-/// [`crate::render::fonts::opentype`], not here: the face catalogue has to spot
-/// a TrueType Collection to enumerate its faces, and it does that whether or not
-/// the `subset-fonts` feature — which gates this whole module — is on.
+/// Font-format detection, and collection-face carving, live with the other
+/// OpenType readers in [`crate::render::fonts::opentype`], not here: the face
+/// catalogue has to spot a TrueType Collection to enumerate its faces, and
+/// `FontRegistry` has to carve a face into a standalone SFNT before handing it
+/// to a platform that declines a non-zero collection index — both whether or
+/// not the `subset-fonts` feature — which gates this whole module — is on.
 /// Re-exported so subsetting's own callers keep their existing paths.
-pub use crate::render::fonts::opentype::{FontFormat, FormatError, SfntFlavor, WoffVersion};
+pub use crate::render::fonts::opentype::{
+    CollectionCarveError, ExtractedSfnt, FontFormat, FormatError, SfntFlavor, WoffVersion,
+};
 pub use apply::{apply, SubsetOutcome, SubsetReport};
 pub use collect::{collect, Codepoint, CodepointUsage};
-pub use extract::{extract, ExtractedSfnt, ExtractionError};
+pub use extract::{extract, ExtractionError};

--- a/src/render/subset/name_splice.rs
+++ b/src/render/subset/name_splice.rs
@@ -12,25 +12,17 @@
 //! shaping or rendering.
 //!
 //! The SFNT assembler this needs — table directory, §5.2 ordering, per-table
-//! checksums and `head.checksumAdjustment` — is also what carving one face out
-//! of a TrueType Collection needs, so `rebuild_sfnt` is shared with the
-//! `extract` module rather than written twice.
+//! checksums and `head.checksumAdjustment` — is
+//! `crate::render::fonts::opentype::sfnt::rebuild_sfnt`, shared with
+//! collection-face carving rather than written twice. It lives outside this
+//! `subset-fonts`-gated module because carving must work without the feature
+//! too — see that function's own doc.
 
-const HEAD_TAG: &[u8; 4] = b"head";
+use crate::render::fonts::opentype::sfnt::rebuild_sfnt;
+
 const NAME_TAG: &[u8; 4] = b"name";
 const SFNT_HEADER_SIZE: usize = 12;
 const TABLE_RECORD_SIZE: usize = 16;
-const HEAD_CHECKSUM_ADJUSTMENT_OFFSET: usize = 8;
-const HEAD_MAGIC: u32 = 0xB1B0_AFBA;
-
-/// Largest table count whose directory search fields are expressible.
-///
-/// OpenType §5.2 defines `searchRange = 2^floor(log2(numTables)) * 16` as a
-/// `uint16`. At 4096 tables that is 65 536 — one past the field's range — and
-/// `rangeShift = numTables * 16 - searchRange` goes with it. The format cannot
-/// describe such a directory at all, so `rebuild_sfnt` declines rather than
-/// writing wrapped values. Real fonts carry on the order of ten tables.
-const MAX_TABLES: usize = 4095;
 
 /// Replace the `name` table in `subsetted` with the one from `original`.
 /// Returns the rebuilt SFNT bytes. If either input lacks a `name` table the
@@ -101,107 +93,6 @@ fn replace_table(sfnt: &[u8], tag: &[u8; 4], new_data: &[u8]) -> Result<Vec<u8>,
     rebuild_sfnt(&sfnt[0..4], tables)
 }
 
-/// Assemble an SFNT from `tables`. Takes ownership so it can enforce the
-/// ascending-tag order OpenType §5.2 requires of the table directory — the sort
-/// used to sit in `replace_table`, which left this function silently producing
-/// an invalid directory for any other caller.
-pub(super) fn rebuild_sfnt(
-    version: &[u8],
-    mut tables: Vec<([u8; 4], Vec<u8>)>,
-) -> Result<Vec<u8>, String> {
-    // Both bounds below used to be handled inline and neither worked. An empty
-    // set took an `if n == 0` branch that set `entry_selector = 0` and then
-    // underflowed on `range_shift = 0*16 - 16`; a large set overflowed
-    // `search_range` in `u16`. Both panicked in debug and wrapped in release.
-    // Returning `Err` instead feeds the caller's existing best-effort path —
-    // `apply.rs` falls back to the unnamed subset rather than aborting.
-    if tables.is_empty() {
-        return Err("cannot build an SFNT with no tables".into());
-    }
-    if tables.len() > MAX_TABLES {
-        return Err(format!(
-            "{} tables exceeds the {MAX_TABLES} a table directory can describe",
-            tables.len()
-        ));
-    }
-    let n = tables.len() as u16;
-    // §5.2: the directory is sorted by tag.
-    tables.sort_by_key(|t| t.0);
-
-    // OpenType §5.2: entrySelector = floor(log2(numTables));
-    // searchRange = 2^entrySelector * 16; rangeShift = numTables*16 - searchRange.
-    // `n >= 1` is guaranteed above, so `leading_zeros() <= 15` and the
-    // subtraction cannot underflow.
-    let entry_selector = 15 - n.leading_zeros() as u16;
-    let search_range = (1u16 << entry_selector) * 16;
-    let range_shift = n * 16 - search_range;
-
-    let dir_size = SFNT_HEADER_SIZE + tables.len() * TABLE_RECORD_SIZE;
-    let mut offsets = Vec::with_capacity(tables.len());
-    let mut cur = dir_size;
-    for (_, data) in &tables {
-        offsets.push(cur);
-        cur += data.len();
-        cur = (cur + 3) & !3; // 4-byte alignment between tables
-    }
-    let total_size = cur;
-
-    let mut out = vec![0u8; total_size];
-    out[0..4].copy_from_slice(version);
-    out[4..6].copy_from_slice(&n.to_be_bytes());
-    out[6..8].copy_from_slice(&search_range.to_be_bytes());
-    out[8..10].copy_from_slice(&entry_selector.to_be_bytes());
-    out[10..12].copy_from_slice(&range_shift.to_be_bytes());
-
-    for (i, ((t, data), &off)) in tables.iter().zip(offsets.iter()).enumerate() {
-        let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-        out[rec..rec + 4].copy_from_slice(t);
-        // checksum filled below
-        out[rec + 8..rec + 12].copy_from_slice(&(off as u32).to_be_bytes());
-        out[rec + 12..rec + 16].copy_from_slice(&(data.len() as u32).to_be_bytes());
-        out[off..off + data.len()].copy_from_slice(data);
-    }
-
-    // §5.2: `head.checksumAdjustment` must read zero for *both* checksums that
-    // cover it — the `head` table's own directory entry and the whole-file
-    // total. Zero it before the loop below, not after: computing the table
-    // checksums first and then changing the field leaves the stored `head`
-    // checksum describing bytes that no longer exist. The whole-file invariant
-    // held either way, which is why nothing downstream noticed.
-    let head_adj_pos = match tables.iter().position(|(t, _)| t == HEAD_TAG) {
-        Some(i) => {
-            // A `head` too short to contain the field would otherwise have its
-            // "adjustment" written into padding or the following table.
-            if tables[i].1.len() < HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4 {
-                return Err("head table too short for checksumAdjustment".into());
-            }
-            let pos = offsets[i] + HEAD_CHECKSUM_ADJUSTMENT_OFFSET;
-            out[pos..pos + 4].copy_from_slice(&0u32.to_be_bytes());
-            Some(pos)
-        }
-        None => None,
-    };
-
-    // Per-table checksums are computed over the padded table region.
-    for (i, ((_, data), &off)) in tables.iter().zip(offsets.iter()).enumerate() {
-        let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-        let padded_len = (data.len() + 3) & !3;
-        let checksum = sfnt_checksum(&out[off..off + padded_len]);
-        out[rec + 4..rec + 8].copy_from_slice(&checksum.to_be_bytes());
-    }
-
-    // §5.2: head.checksumAdjustment = 0xB1B0AFBA - whole-file checksum, taken
-    // with every directory entry final and the field itself still zero. Writing
-    // it is the last mutation, so the file then sums to the magic exactly.
-    if let Some(pos) = head_adj_pos {
-        let total = sfnt_checksum(&out);
-        let adjustment = HEAD_MAGIC.wrapping_sub(total);
-        out[pos..pos + 4].copy_from_slice(&adjustment.to_be_bytes());
-    }
-
-    Ok(out)
-}
-
 fn read_num_tables(sfnt: &[u8]) -> Result<usize, String> {
     if sfnt.len() < SFNT_HEADER_SIZE {
         return Err("sfnt too short".into());
@@ -216,23 +107,6 @@ fn read_u32(buf: &[u8], offset: usize) -> u32 {
         buf[offset + 2],
         buf[offset + 3],
     ])
-}
-
-/// Sum the buffer as big-endian u32 values, with zero-padding at the tail
-/// if the length isn't 4-aligned.
-fn sfnt_checksum(data: &[u8]) -> u32 {
-    let mut sum: u32 = 0;
-    let chunks = data.chunks_exact(4);
-    let rem = chunks.remainder();
-    for c in chunks {
-        sum = sum.wrapping_add(u32::from_be_bytes([c[0], c[1], c[2], c[3]]));
-    }
-    if !rem.is_empty() {
-        let mut padded = [0u8; 4];
-        padded[..rem.len()].copy_from_slice(rem);
-        sum = sum.wrapping_add(u32::from_be_bytes(padded));
-    }
-    sum
 }
 
 #[cfg(test)]
@@ -272,102 +146,15 @@ mod tests {
         assert_eq!(post.family_name(), "Carlito");
     }
 
-    // ── `rebuild_sfnt` directory fields ──────────────────────────────────
-    //
-    // None of these needs a font on the host, which is the point: the only
-    // test this file had was gated on Carlito being installed, so every
-    // boundary below was unreachable by the suite (F1#5).
+    // `rebuild_sfnt`'s own directory/checksum boundary tests live with its
+    // definition now (`fonts::opentype::sfnt`) — this file only needs to pin
+    // `replace_table`'s own behavior: substituting a table that's present,
+    // and appending one that's absent.
+
+    const HEAD_TAG: &[u8; 4] = b"head";
 
     fn tbl(tag: &[u8; 4], len: usize) -> ([u8; 4], Vec<u8>) {
         (*tag, vec![0u8; len])
-    }
-
-    /// Synthetic table sets of arbitrary size, for the boundary cases.
-    fn many(n: usize) -> Vec<([u8; 4], Vec<u8>)> {
-        (0..n)
-            .map(|i| {
-                let mut t = [0u8; 4];
-                t.copy_from_slice(&format!("{i:04x}").as_bytes()[..4]);
-                (t, vec![0u8; 4])
-            })
-            .collect()
-    }
-
-    fn dir_fields(sfnt: &[u8]) -> (u16, u16, u16, u16) {
-        let g = |o: usize| u16::from_be_bytes([sfnt[o], sfnt[o + 1]]);
-        (g(4), g(6), g(8), g(10)) // numTables, searchRange, entrySelector, rangeShift
-    }
-
-    /// OpenType §5.2's own formulas, spelled out independently of the
-    /// implementation so the test cannot inherit its arithmetic.
-    #[test]
-    fn directory_search_fields_follow_the_spec_formulas() {
-        for n in [1usize, 2, 3, 4, 7, 8, 15, 16, 17, 100, 4095] {
-            let out = rebuild_sfnt(b"\x00\x01\x00\x00", many(n)).expect("n={n}");
-            let (num, search_range, entry_selector, range_shift) = dir_fields(&out);
-            let expected_sel = (usize::BITS - 1 - n.leading_zeros()) as u16; // floor(log2 n)
-            let expected_range = (1u32 << expected_sel) * 16;
-            assert_eq!(num as usize, n, "numTables for n={n}");
-            assert_eq!(entry_selector, expected_sel, "entrySelector for n={n}");
-            assert_eq!(search_range as u32, expected_range, "searchRange for n={n}");
-            assert_eq!(
-                range_shift as u32,
-                n as u32 * 16 - expected_range,
-                "rangeShift for n={n}"
-            );
-        }
-    }
-
-    /// 4096 is where `searchRange` would be 65 536 — one past `uint16`. The
-    /// old code panicked here in debug and wrapped in release; it now declines,
-    /// and 4095 still succeeds so the bound is exact rather than conservative.
-    #[test]
-    fn the_table_count_bound_is_exact() {
-        assert!(
-            rebuild_sfnt(b"\x00\x01\x00\x00", many(MAX_TABLES)).is_ok(),
-            "{MAX_TABLES} tables must still build"
-        );
-        let err = rebuild_sfnt(b"\x00\x01\x00\x00", many(MAX_TABLES + 1))
-            .expect_err("one past the bound must be declined, not wrapped");
-        assert!(err.contains("exceeds"), "got: {err}");
-    }
-
-    /// The empty set took a guard that set `entry_selector = 0` and then
-    /// underflowed computing `rangeShift`. Unreachable from `replace_table`,
-    /// which always pushes at least one table — but the function is callable
-    /// on its own, and a guard that panics is not a guard.
-    #[test]
-    fn an_empty_table_set_is_declined_not_underflowed() {
-        let err = rebuild_sfnt(b"\x00\x01\x00\x00", Vec::new()).expect_err("must decline");
-        assert!(err.contains("no tables"), "got: {err}");
-    }
-
-    /// Tables are laid out in tag order with 4-byte alignment between them,
-    /// and every directory entry must point at its own data.
-    #[test]
-    fn tables_are_sorted_by_tag_and_four_byte_aligned() {
-        // Deliberately out of order, with a length that forces padding.
-        let tables = vec![tbl(b"zzzz", 5), tbl(b"aaaa", 3), tbl(b"mmmm", 4)];
-        let out = rebuild_sfnt(b"\x00\x01\x00\x00", tables.clone()).expect("build");
-        let n = u16::from_be_bytes([out[4], out[5]]) as usize;
-        assert_eq!(n, 3);
-
-        let mut seen = Vec::new();
-        for i in 0..n {
-            let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-            let tag = &out[rec..rec + 4];
-            let off = read_u32(&out, rec + 8) as usize;
-            let len = read_u32(&out, rec + 12) as usize;
-            assert_eq!(off % 4, 0, "table {i} is not 4-byte aligned");
-            assert!(off + len <= out.len(), "table {i} runs past the buffer");
-            seen.push(tag.to_vec());
-            // The recorded length is the *unpadded* one.
-            let expected = tables.iter().find(|(t, _)| t == tag).expect("known tag");
-            assert_eq!(len, expected.1.len(), "length for {:?}", tag);
-        }
-        let mut sorted = seen.clone();
-        sorted.sort();
-        assert_eq!(seen, sorted, "directory must be sorted by tag");
     }
 
     /// A table absent from the input is appended rather than dropped — the
@@ -384,125 +171,5 @@ mod tests {
             find_table(&out, HEAD_TAG).expect("scan").is_some(),
             "the existing table must survive"
         );
-    }
-
-    // ── OpenType §5.2 checksums ──────────────────────────────────────────
-
-    /// Recompute a table's directory checksum the way a validator would.
-    fn stored_and_actual(sfnt: &[u8], tag: &[u8; 4]) -> Option<(u32, u32)> {
-        let n = u16::from_be_bytes([sfnt[4], sfnt[5]]) as usize;
-        (0..n).find_map(|i| {
-            let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-            (&sfnt[rec..rec + 4] == tag).then(|| {
-                let stored = read_u32(sfnt, rec + 4);
-                let off = read_u32(sfnt, rec + 8) as usize;
-                let len = read_u32(sfnt, rec + 12) as usize;
-                let padded = (len + 3) & !3;
-                (stored, sfnt_checksum(&sfnt[off..off + padded]))
-            })
-        })
-    }
-
-    /// §5.2: the whole font, summed as big-endian `u32`s with
-    /// `checksumAdjustment` in place, must equal `0xB1B0AFBA`.
-    #[test]
-    fn the_whole_file_sums_to_the_head_magic() {
-        let mut head = vec![0u8; 54];
-        head[8..12].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
-        let out = rebuild_sfnt(
-            b"\x00\x01\x00\x00",
-            vec![(*b"head", head), (*b"name", vec![1, 2, 3, 4, 5])],
-        )
-        .expect("build");
-        assert_eq!(sfnt_checksum(&out), HEAD_MAGIC);
-    }
-
-    /// §5.2: `head`'s *directory* checksum is the one taken with
-    /// `checksumAdjustment` zeroed.
-    ///
-    /// Previously the per-table loop ran first and the field was rewritten
-    /// afterwards, so the stored value described bytes that no longer existed —
-    /// it came out as the caller's incoming garbage (`0xdeadbeef` here) rather
-    /// than the spec's value. The whole-file invariant above still held, which
-    /// is exactly why this went unnoticed.
-    #[test]
-    fn head_directory_checksum_is_taken_with_the_adjustment_zeroed() {
-        let mut head = vec![0u8; 54];
-        head[8..12].copy_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
-        let out = rebuild_sfnt(
-            b"\x00\x01\x00\x00",
-            vec![(*b"head", head), (*b"name", vec![9, 9, 9, 9])],
-        )
-        .expect("build");
-
-        let (stored, _) = stored_and_actual(&out, HEAD_TAG).expect("head present");
-        // Reconstruct the spec value: head's bytes with the field zeroed.
-        let n = u16::from_be_bytes([out[4], out[5]]) as usize;
-        let (off, len) = (0..n)
-            .find_map(|i| {
-                let rec = SFNT_HEADER_SIZE + i * TABLE_RECORD_SIZE;
-                (&out[rec..rec + 4] == HEAD_TAG).then(|| {
-                    (
-                        read_u32(&out, rec + 8) as usize,
-                        read_u32(&out, rec + 12) as usize,
-                    )
-                })
-            })
-            .expect("head record");
-        let mut zeroed = out[off..off + ((len + 3) & !3)].to_vec();
-        zeroed[HEAD_CHECKSUM_ADJUSTMENT_OFFSET..HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4]
-            .copy_from_slice(&0u32.to_be_bytes());
-
-        assert_eq!(stored, sfnt_checksum(&zeroed), "§5.2 head checksum");
-        assert_ne!(
-            stored, 0xDEAD_BEEF,
-            "must not be the caller's incoming adjustment"
-        );
-    }
-
-    /// Every non-`head` table's stored checksum must match its bytes exactly —
-    /// nothing rewrites those after the loop.
-    #[test]
-    fn non_head_directory_checksums_match_their_bytes() {
-        let out = rebuild_sfnt(
-            b"\x00\x01\x00\x00",
-            vec![
-                (*b"head", vec![0u8; 54]),
-                (*b"name", vec![7; 13]),
-                (*b"cmap", vec![3; 8]),
-            ],
-        )
-        .expect("build");
-        for tag in [b"name", b"cmap"] {
-            let (stored, actual) = stored_and_actual(&out, tag).expect("table present");
-            assert_eq!(
-                stored,
-                actual,
-                "checksum for {:?}",
-                std::str::from_utf8(tag)
-            );
-        }
-    }
-
-    /// A font with no `head` still builds — the adjustment step is simply
-    /// skipped, and no whole-file invariant applies without the field.
-    #[test]
-    fn a_font_without_head_still_builds() {
-        let out = rebuild_sfnt(b"\x00\x01\x00\x00", vec![(*b"name", vec![1, 2, 3, 4])])
-            .expect("build without head");
-        let (stored, actual) = stored_and_actual(&out, b"name").expect("name present");
-        assert_eq!(stored, actual);
-    }
-
-    /// A `head` too short to hold `checksumAdjustment` is declined. Writing at
-    /// its nominal offset would have landed in padding or the next table.
-    #[test]
-    fn a_truncated_head_is_declined_not_written_past() {
-        let err = rebuild_sfnt(
-            b"\x00\x01\x00\x00",
-            vec![(*b"head", vec![0u8; 8]), (*b"name", vec![1, 2, 3, 4])],
-        )
-        .expect_err("must decline");
-        assert!(err.contains("head table too short"), "got: {err}");
     }
 }

--- a/tests/font_resolution.rs
+++ b/tests/font_resolution.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use dxpdf::render::fonts::catalog::Scope;
 use dxpdf::render::fonts::face::NameKind;
-use dxpdf::render::fonts::opentype::{FontFormat, NameId};
+use dxpdf::render::fonts::opentype::{carve_collection_face, FontFormat, NameId};
 use dxpdf::render::fonts::resolve::{resolve, FaceResolution, FallbackReason, ResolutionStep};
 use dxpdf::render::fonts::{FaceCatalog, FaceRequest, Toggle};
 use skia_safe::{FontMgr, Typeface};
@@ -24,6 +24,25 @@ use skia_safe::{FontMgr, Typeface};
 
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-files/fonts")
+}
+
+/// Open one face, carving it out of a collection first (issue #116) — the
+/// same strategy `FontRegistry::open_embedded_typeface` uses internally, so
+/// this loader exercises fixtures the same way the real registry does rather
+/// than asking the platform to interpret a collection index directly (which
+/// Skia's CoreText backend declines for any index but 0).
+fn open_fixture_face(
+    font_mgr: &FontMgr,
+    bytes: &[u8],
+    index: u32,
+    face_count: u32,
+) -> Option<Typeface> {
+    if face_count <= 1 {
+        return font_mgr.new_from_data(bytes, 0);
+    }
+    let carved = carve_collection_face(bytes, index, face_count)
+        .unwrap_or_else(|e| panic!("carving face {index} of {face_count}: {e}"));
+    font_mgr.new_from_data(&carved.bytes, 0)
 }
 
 /// Load one fixture, naming every face it contains.
@@ -43,7 +62,7 @@ fn load(font_mgr: &FontMgr, filename: &str) -> Vec<(String, Typeface)> {
 
     (0..face_count)
         .filter_map(|index| {
-            let typeface = font_mgr.new_from_data(&bytes[..], index as usize)?;
+            let typeface = open_fixture_face(font_mgr, &bytes, index, face_count)?;
             Some((typeface.family_name(), typeface))
         })
         .collect()
@@ -66,8 +85,8 @@ fn catalog() -> FaceCatalog {
         faces.extend(load(&font_mgr, filename));
     }
     assert!(
-        faces.len() >= 8,
-        "expected at least eight fixture faces, got {}",
+        faces.len() >= 9,
+        "expected at least nine fixture faces, got {}",
         faces.len()
     );
     FaceCatalog::from_faces(font_mgr, &faces)
@@ -119,11 +138,10 @@ fn the_fixtures_carry_what_the_tests_assume() {
         "fixtures are host faces, not embedded ones"
     );
 
-    // `DxCollection.ttc` carries two faces, but how many the *platform* will
-    // open is not universal: Skia's CoreText backend declines a non-zero
-    // collection index outright, so on macOS only face 0 is reachable. The file
-    // itself is what the assertion is about — `FontFormat::detect` reads the
-    // header, and the subset pass carves faces from those bytes directly.
+    // `DxCollection.ttc` carries two faces, and both are reachable on every
+    // platform (issue #116): `load()` carves each face into a standalone SFNT
+    // before opening it, so Skia's CoreText backend — which declines any
+    // collection index but 0 — is never asked to interpret one directly.
     let ttc = std::fs::read(fixture_dir().join("DxCollection.ttc")).unwrap();
     assert!(
         matches!(
@@ -133,9 +151,10 @@ fn the_fixtures_carry_what_the_tests_assume() {
         "DxCollection.ttc must declare two faces"
     );
     let openable = load(&font_mgr, "DxCollection.ttc");
-    assert!(
-        !openable.is_empty(),
-        "the platform must open at least the first collection face"
+    assert_eq!(
+        openable.len(),
+        2,
+        "both collection faces must open on every platform"
     );
 
     let variable = load(&font_mgr, "DxVariable.ttf");
@@ -404,10 +423,14 @@ fn a_face_name_shared_by_two_faces_is_reported_as_ambiguous() {
 fn each_collection_face_resolves_to_itself() {
     let font_mgr = FontMgr::new();
     let faces = load(&font_mgr, "DxCollection.ttc");
+    assert_eq!(
+        faces.len(),
+        2,
+        "both collection faces must be reachable on every platform"
+    );
 
-    // Every face the platform *does* open must be reachable by its own name and
-    // distinguishable from its siblings. On a backend that declines a non-zero
-    // collection index this checks one face; on one that does not, both.
+    // Every face must be reachable by its own name and distinguishable from
+    // its siblings.
     let expected: &[(&str, i32)] = &[("Dx Collection One", 400), ("Dx Collection Two", 700)];
     for (index, _) in faces.iter().enumerate() {
         let (family, weight) = expected[index];
@@ -424,7 +447,6 @@ fn each_collection_face_resolves_to_itself() {
         );
         assert_eq!(weight_of(family, Toggle::Absent, Toggle::Absent), weight);
     }
-    assert!(!faces.is_empty(), "no collection face opened at all");
 }
 
 // ─── Acceptance: variable named instances ───────────────────────────────────


### PR DESCRIPTION
- Simplified the extraction process for TrueType Collections (TTC) by introducing `carve_collection_face` to handle face carving directly.
- Updated `ExtractionError` to encapsulate collection-related errors through `CollectionCarveError`.
- Removed redundant code for face carving from `extract.rs` and centralized it in the `opentype` module.
- Enhanced error handling in `classify_and_unwrap` to properly report collection errors.
- Adjusted tests to validate the new extraction logic and ensure both faces in a collection are accessible.
- Updated documentation to clarify the relationship between font format detection and collection handling.