### PR TITLE
feat: add Debian packaging support and verify script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,130 @@ jobs:
         if: matrix.target.os != 'windows'
         shell: bash
         run: python3 scripts/verify_wheel.py dist/*.whl
+
+  # The Debian package (issue #92). Built inside a debian:12 container rather
+  # than on the Ubuntu runner, for two reasons that both bite:
+  #
+  #   * `depends = "$auto"` runs dpkg-shlibdeps, which resolves the binary's
+  #     DT_NEEDED entries against the packages of whatever distribution it runs
+  #     on. Run on Ubuntu, it produces Ubuntu's answer.
+  #   * glibc is a floor, not a ceiling. Built on ubuntu-latest the package
+  #     requires glibc 2.39 and will not install on Debian 12 at all — which is
+  #     the audience the request came from. Bookworm's 2.36 covers Debian 12
+  #     and 13, Ubuntu 24.04+, and their derivatives.
+  #
+  # amd64 only here: the release matrix in `deb.yml` builds both architectures,
+  # and each one is a full Skia build. Keep the apt list, the clang version and
+  # the cargo-deb invocation in sync with that workflow — this job exists to
+  # catch a packaging break on the PR that causes it, so a divergence means it
+  # is validating something other than what gets published.
+  build-deb:
+    name: Build Debian package (amd64)
+    runs-on: ubuntu-latest
+    needs: [check, test]
+    container: debian:12-slim
+    steps:
+      # Ahead of checkout, so the action finds git and makes a real clone
+      # instead of falling back to a source tarball.
+      #
+      # clang-19, not bookworm's default clang 14: Skia m150 uses C++20
+      # <ranges>, which clang 14 cannot compile against GCC 12's libstdc++ — it
+      # fails in SkPDFTag.cpp with "no matching function for call to object of
+      # type 'const std::ranges::views::_Reverse'". clang-19 is in bookworm
+      # main, so this needs no backports.
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential clang-19 libclang-19-dev ninja-build python3 \
+            curl ca-certificates git pkg-config \
+            libfontconfig1-dev libfreetype-dev lintian
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Built from source rather than fetched by a third-party installer
+      # action: it is a couple of minutes against a Skia build that dominates
+      # this job anyway, and it keeps the release path free of an extra
+      # dependency.
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Build package
+        run: cargo deb
+        env:
+          CC: clang-19
+          CXX: clang++-19
+
+      - name: Verify package contents
+        run: python3 scripts/verify_deb.py target/debian/*.deb
+
+      # No `--suppress-tags`: the only tags that are allowed to fire are the
+      # ones the package explains for itself in
+      # debian/dxpdf.lintian-overrides, which it ships to
+      # /usr/share/lintian/overrides/dxpdf. A new error or warning fails here.
+      - name: Lint package
+        run: lintian --fail-on error,warning --tag-display-limit 0 target/debian/*.deb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb-amd64
+          path: target/debian/*.deb
+
+  # The acceptance test, and the reason it is a separate job: this container
+  # has no toolchain and no -dev packages, so it is the first machine in the
+  # pipeline that can prove the dependency list is complete. Running it in
+  # build-deb would prove nothing — everything the binary needs is already
+  # there because it was just used to compile it.
+  test-deb-install:
+    name: Install Debian package
+    runs-on: ubuntu-latest
+    needs: build-deb
+    container: debian:12-slim
+    steps:
+      - name: Install test prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates git poppler-utils man-db groff-base
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: deb-amd64
+          path: pkg
+
+      # Debian's own container images carry
+      # /etc/dpkg/dpkg.cfg.d/docker, which sets `path-exclude
+      # /usr/share/man/*` to keep the image small. Leaving it in place would
+      # make dpkg silently drop the man page on install and this job would
+      # "prove" the package has none. No real Debian system has that file.
+      - name: Install the package the way a user would
+        run: |
+          rm -f /etc/dpkg/dpkg.cfg.d/docker
+          apt-get install -y ./pkg/*.deb
+
+      - name: Recommends were honoured
+        run: dpkg-query -W -f='${Package} ${Status}\n' fonts-liberation2
+
+      - name: The installed program answers for itself
+        run: |
+          dxpdf --version
+          dxpdf --help > /dev/null
+          test -s /usr/share/doc/dxpdf/copyright
+          test -s /usr/share/doc/dxpdf/changelog.Debian.gz
+          man --warnings -E UTF-8 -l /usr/share/man/man1/dxpdf.1.gz > /dev/null
+
+      # Conversion, not just startup: a package that installs and then cannot
+      # render is the failure mode a dependency list gets wrong.
+      - name: Convert a document
+        run: |
+          dxpdf test-files/sample-docx-files-sample1.docx -o /tmp/out.pdf
+          head -c 5 /tmp/out.pdf | grep -q '%PDF-'
+          chars=$(pdftotext /tmp/out.pdf - | tr -d '[:space:]' | wc -c)
+          echo "extracted $chars characters of text"
+          test "$chars" -gt 1000

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,91 @@
+name: Publish Debian packages
+
+# Separate from `publish.yml` (crates.io) on purpose: a Debian build that fails
+# must not be able to hold up the crate publish, and the two need completely
+# different environments — this one runs inside a Debian container, that one on
+# the runner.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build .deb (${{ matrix.target.arch }})
+    runs-on: ${{ matrix.target.runner }}
+    container: debian:12-slim
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          # Both native — no QEMU. Same pair of runners the wheel matrix in
+          # `python.yml` uses, for the same reason.
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      # Keep this list, the clang version, and the cargo-deb invocation in step
+      # with the `build-deb` job in `ci.yml` — that job is what validates this
+      # one on every pull request, and it can only do that while the two agree.
+      # The reasoning behind the container base and clang-19 is written out
+      # there rather than repeated here.
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential clang-19 libclang-19-dev ninja-build python3 \
+            curl ca-certificates git pkg-config \
+            libfontconfig1-dev libfreetype-dev lintian
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Build package
+        run: cargo deb
+        env:
+          CC: clang-19
+          CXX: clang++-19
+
+      - name: Verify package contents
+        run: python3 scripts/verify_deb.py target/debian/*.deb
+
+      - name: Lint package
+        run: lintian --fail-on error,warning --tag-display-limit 0 target/debian/*.deb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{ matrix.target.arch }}
+          path: target/debian/*.deb
+
+  publish:
+    name: Attach to release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      # `gh release upload` writes to the release this workflow was triggered
+      # by; nothing else here needs write access.
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      # `--clobber` so that re-running this workflow on a release replaces the
+      # assets instead of failing on the second attempt.
+      - name: Upload to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ls -l dist
+          gh release upload "${{ github.event.release.tag_name }}" dist/*.deb \
+            --clobber --repo "$GITHUB_REPOSITORY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,24 @@ magick compare -metric AE /tmp/before-1.png /tmp/after-1.png null:
 
 For any paint or subset change, pixel-diff before vs after — a passing test suite does not prove the output is unchanged.
 
+**Debian package** (issue #92) — `cargo deb` builds it from `[package.metadata.deb]` in `Cargo.toml`; `scripts/verify_deb.py` checks the result and `tests/packaging.rs` checks the inputs (man page in step with `--help`, `debian/changelog` in step with the version). CI builds amd64 on every PR and `deb.yml` builds both architectures per release.
+
+It has to be built **inside a `debian:12` container**, and both halves of that matter. `depends = "$auto"` runs `dpkg-shlibdeps`, which resolves the binary against the packages of whatever distribution it runs on. And glibc is a floor, not a ceiling: built on `ubuntu-latest` the package requires glibc 2.39 and will not install on Debian 12 at all. Bookworm's 2.36 reaches Debian 12 and 13, Ubuntu 24.04+, and derivatives — moving that base later silently drops users who have already installed. Use `clang-19`, not bookworm's default clang 14, which cannot compile Skia m150's C++20 `<ranges>` against GCC 12's libstdc++.
+
+```bash
+docker run --rm -v "$PWD:/w" -w /w debian:12-slim bash -c '
+  apt-get update && apt-get install -y --no-install-recommends \
+    build-essential clang-19 libclang-19-dev ninja-build python3 curl \
+    ca-certificates git pkg-config libfontconfig1-dev libfreetype-dev lintian
+  curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+  . "$HOME/.cargo/env"; export CC=clang-19 CXX=clang++-19
+  cargo install cargo-deb --locked && cargo deb
+  python3 scripts/verify_deb.py target/debian/*.deb
+  lintian --fail-on error,warning target/debian/*.deb'
+```
+
+Two things that are not obvious from the files. The `assets` list is explicit because cargo-deb's default set also picks up C-ABI dynamic libraries, and `crate-type = ["rlib", "cdylib"]` means a release build emits `libdxpdf.so` — the PyO3 extension body, which has no business in `/usr/lib`. And when testing an install in a Debian *container*, delete `/etc/dpkg/dpkg.cfg.d/docker` first: it sets `path-exclude /usr/share/man/*`, so dpkg drops the man page and the test appears to prove the package has none.
+
 **Before handing work back**, run what CI runs (`.github/workflows/ci.yml`):
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "skia-safe",
  "tempfile",
  "thiserror 2.0.20",
+ "toml",
  "unicode-bidi",
  "unicode-bidi-mirroring",
  "unicode-joining-type",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dxpdf"
 version = "0.4.0"
 edition = "2021"
-description = "A fast DOCX-to-PDF converter powered by Skia"
+description = "Fast DOCX-to-PDF converter powered by Skia"
 license = "MIT"
 repository = "https://github.com/nerdy-pro/dxpdf"
 homepage = "https://nerdy.pro"
@@ -14,6 +14,81 @@ exclude = ["test-cases/", "test-files/", "scripts/", "output/", "plans/"]
 
 [lib]
 crate-type = ["rlib", "cdylib"]
+
+# Debian package (issue #92), built by `cargo deb` and attached to each GitHub
+# release by `.github/workflows/deb.yml`. This is an upstream-built `.deb`, not
+# an upload to the Debian archive, and the difference is not a matter of
+# polish: `skia-bindings` ships a 270 KB crate with no Skia in it and clones
+# the C++ tree during its build script — which is why `git` is a build
+# dependency of this package at all. Debian builds on machines with no network
+# and no vendored third-party C++, so the archive route stays closed until
+# somebody packages Skia for Debian. Nothing here changes that; it does mean a
+# Debian user can install the CLI today, and it shortens the job if that route
+# ever opens.
+#
+# `scripts/verify_deb.py` checks the resulting package and `tests/packaging.rs`
+# checks this table; between them, most of what is written below is enforced.
+[package.metadata.deb]
+maintainer = "Ilya Nixan <nixan@nerdy.pro>"
+copyright = "2025-2026 Ilya Nixan <nixan@nerdy.pro>"
+# `[package] license = "MIT"` names the licence; this ships its text, which
+# Policy §12.5 requires in /usr/share/doc/dxpdf/copyright. The 0 is how many
+# leading lines to skip — our LICENSE starts directly with the licence.
+license-file = ["LICENSE", "0"]
+# `text` is where the other document converters live (pandoc, docx2txt).
+section = "text"
+priority = "optional"
+# dpkg-shlibdeps, which reads the built binary's DT_NEEDED entries. It only
+# works on a Debian host, which is why CI builds inside a debian:12 container
+# rather than on the Ubuntu runner: the dependency list has to be computed
+# against the distribution the package claims to support.
+depends = "$auto"
+# Not `depends`: the package works without these, it just renders worse, and a
+# user with their own font set should not be made to take Liberation as well.
+#
+# What they actually buy, measured on a bookworm container with
+# `test-files/sample-docx-files-sample1.docx`: a bare install already has one
+# font family, because `libfontconfig1` pulls `fonts-dejavu-core` in as a hard
+# dependency — so the failure is not blank text, it is *wrong* text. That
+# document's request for Courier New resolved to DejaVu **Sans**, a
+# proportional face standing in for a monospace one. With `fonts-liberation2`
+# present it resolves to Liberation Mono, which is metric-compatible with
+# Courier New, and one of the three unmatched-font warnings goes away.
+# Liberation covers Arial, Times New Roman and Courier New — between them, most
+# of what a .docx asks for. The `|` alternative covers releases carrying only
+# the older package name.
+recommends = "fonts-liberation2 | fonts-liberation, fonts-dejavu-core"
+# Policy §12.7 requires one, and cargo-deb does not synthesise it — without
+# this key there is simply no changelog.Debian.gz in the package. It is
+# committed rather than generated so that `apt changelog dxpdf` says something
+# a human wrote; `tests/packaging.rs` fails if its top entry falls behind
+# `[package] version`, which is what stops it going stale.
+changelog = "debian/changelog"
+# There is deliberately no `description` key here: cargo-deb has none, so the
+# package synopsis is always `[package] description` above. That is why it no
+# longer opens with "A" — lintian's `description-synopsis-starts-with-article`,
+# which cannot be fixed anywhere but there.
+extended-description = """\
+dxpdf converts Word documents in Office Open XML format (.docx) to PDF. \
+Layout is performed by dxpdf itself and rendering by Skia, so no office suite \
+is required and nothing is sent over the network.
+
+Fonts are resolved through fontconfig from those installed on the machine, \
+together with any fonts embedded in the document."""
+# Explicit, because cargo-deb's default asset set also picks up C-ABI dynamic
+# libraries — and this crate is `crate-type = ["rlib", "cdylib"]`, so a release
+# build emits `libdxpdf.so` as well as the binary. That file is the body of the
+# PyO3 extension module: no soname, no headers, no ABI promise, and nothing
+# that should be in /usr/lib. `verify_deb.py` fails the build if it appears.
+assets = [
+    ["target/release/dxpdf", "usr/bin/", "755"],
+    ["man/dxpdf.1", "usr/share/man/man1/", "644"],
+    ["README.md", "usr/share/doc/dxpdf/README.md", "644"],
+    # Reasons for the lintian tags that cannot be fixed, shipped with the
+    # package so they travel with it. CI suppresses nothing else, so a new tag
+    # fails the build.
+    ["debian/dxpdf.lintian-overrides", "usr/share/lintian/overrides/dxpdf", "644"],
+]
 
 [dependencies]
 bitflags = "2"
@@ -156,6 +231,12 @@ subset-fonts = ["dep:fontcull"]
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 lopdf = { version = "0.44", default-features = false }
+# Reads `[package.metadata.deb]` back out of this file in `tests/packaging.rs`,
+# so a renamed asset fails at `cargo test` time instead of during a release
+# build. Already in `Cargo.lock` as a transitive dependency, so naming it here
+# only changes which line pulls it in — and being dev-only it reaches neither
+# the crate, the wheel, nor the `.deb`.
+toml = "1"
 
 [[bench]]
 name = "convert_bench"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ Built by [nerdy.pro](https://nerdy.pro).
 cargo install dxpdf
 ```
 
+### Debian / Ubuntu
+
+Every [release](https://github.com/nerdy-pro/dxpdf/releases) ships a `.deb` for
+`amd64` and `arm64`:
+
+```bash
+curl -LO https://github.com/nerdy-pro/dxpdf/releases/download/v0.4.0/dxpdf_0.4.0-1_amd64.deb
+sudo apt install ./dxpdf_0.4.0-1_amd64.deb
+```
+
+Installs `dxpdf` to `/usr/bin` with a `dxpdf(1)` man page, and recommends
+`fonts-liberation2` — metric-compatible with Arial, Times New Roman and Courier
+New, so documents that ask for them lay out the way Word does.
+
+Built on Debian 12, so it installs on Debian 12 and 13, Ubuntu 24.04 and newer,
+and their derivatives. Not yet in the Debian archive itself
+([#92](https://github.com/nerdy-pro/dxpdf/issues/92)): that needs a Skia that
+Debian packages, and there is not one.
+
 ### Rust Library
 
 Add to your `Cargo.toml`:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,9 @@
+dxpdf (0.4.0-1) unstable; urgency=medium
+
+  * Initial Debian package, built upstream and attached to the GitHub release
+    rather than uploaded to the Debian archive (see issue #92). The archive
+    route needs a Skia that Debian itself packages; there is not one yet.
+  * Per-version upstream changes are in the GitHub release notes:
+    https://github.com/nerdy-pro/dxpdf/releases
+
+ -- Ilya Nixan <nixan@nerdy.pro>  Mon, 10 Aug 2026 19:00:00 +0000

--- a/debian/dxpdf.lintian-overrides
+++ b/debian/dxpdf.lintian-overrides
@@ -1,0 +1,22 @@
+# Lintian overrides, shipped in the package at
+# /usr/share/lintian/overrides/dxpdf. Everything here is a tag that cannot be
+# fixed without changing what dxpdf is; CI runs lintian with no suppression
+# beyond this file, so any *new* error or warning fails the build.
+
+# Skia is compiled from source by `skia-bindings` and statically links its own
+# copies of these libraries. That is deliberate rather than an oversight:
+# `skia-safe`'s `embed-freetype` feature exists because linking the host
+# FreeType made dxpdf abort at load time with "undefined symbol:
+# FT_Palette_Data_Get" on any machine whose FreeType predated the build's, and
+# `scripts/verify_deb.py` fails the build if FreeType ever reappears in
+# Depends. Unbundling them needs a Debian-packaged Skia, which does not exist —
+# the same fact that keeps this package out of the Debian archive (issue #92).
+dxpdf: embedded-library expat [usr/bin/dxpdf]
+dxpdf: embedded-library freetype [usr/bin/dxpdf]
+dxpdf: embedded-library libjpeg [usr/bin/dxpdf]
+
+# The tag wants the first changelog entry to close an ITP bug. This package is
+# built upstream and attached to a GitHub release; it is not an upload to the
+# Debian archive, so it closes nothing. Debian RFP #1142914 stays open, and
+# claiming otherwise in the changelog would be false.
+dxpdf: initial-upload-closes-no-bugs [usr/share/doc/dxpdf/changelog.Debian.gz:1]

--- a/debian/dxpdf.lintian-overrides
+++ b/debian/dxpdf.lintian-overrides
@@ -1,22 +1,31 @@
 # Lintian overrides, shipped in the package at
 # /usr/share/lintian/overrides/dxpdf. Everything here is a tag that cannot be
-# fixed without changing what dxpdf is; CI runs lintian with no suppression
-# beyond this file, so any *new* error or warning fails the build.
+# fixed without changing what dxpdf is; CI suppresses nothing beyond this file,
+# so any *new* error or warning fails the build.
+#
+# Each line names a tag and nothing else. Writing the context as well — the
+# form `dxpdf: embedded-library expat [usr/bin/dxpdf]` that lintian itself
+# prints — is not portable across architectures: it matched exactly on an arm64
+# build and came back as `mismatched-override` on amd64, failing the release.
+# Which C-library fingerprints lintian finds inside a statically linked binary
+# is a property of that build, so an override that has to predict them will
+# eventually be wrong. A bare tag name matches every instance, and an override
+# that matches nothing is only a note, not a failure — both measured against
+# lintian 2.116.
 
 # Skia is compiled from source by `skia-bindings` and statically links its own
-# copies of these libraries. That is deliberate rather than an oversight:
+# copies of several C libraries; on the arm64 build the ones lintian recognises
+# are expat, freetype and libjpeg. That is deliberate rather than an oversight:
 # `skia-safe`'s `embed-freetype` feature exists because linking the host
 # FreeType made dxpdf abort at load time with "undefined symbol:
 # FT_Palette_Data_Get" on any machine whose FreeType predated the build's, and
 # `scripts/verify_deb.py` fails the build if FreeType ever reappears in
 # Depends. Unbundling them needs a Debian-packaged Skia, which does not exist —
 # the same fact that keeps this package out of the Debian archive (issue #92).
-dxpdf: embedded-library expat [usr/bin/dxpdf]
-dxpdf: embedded-library freetype [usr/bin/dxpdf]
-dxpdf: embedded-library libjpeg [usr/bin/dxpdf]
+dxpdf: embedded-library
 
 # The tag wants the first changelog entry to close an ITP bug. This package is
 # built upstream and attached to a GitHub release; it is not an upload to the
 # Debian archive, so it closes nothing. Debian RFP #1142914 stays open, and
 # claiming otherwise in the changelog would be false.
-dxpdf: initial-upload-closes-no-bugs [usr/share/doc/dxpdf/changelog.Debian.gz:1]
+dxpdf: initial-upload-closes-no-bugs

--- a/man/dxpdf.1
+++ b/man/dxpdf.1
@@ -1,0 +1,122 @@
+.\" Manual page for dxpdf. Debian Policy §12.1 requires one for every program
+.\" in /usr/bin, so this file is a hard prerequisite of the .deb rather than a
+.\" nicety, and tests/packaging.rs keeps it in step with `dxpdf --help`.
+.\"
+.\" The source string below is deliberately just "dxpdf" with no version: this
+.\" file is not generated, so an embedded version would be wrong from the first
+.\" release after anyone forgot to bump it, and a stale version is worse than
+.\" none. The date is the date this page last changed, which is what a man page
+.\" date is supposed to mean.
+.\"
+.\" Hyphens are written \- throughout. A bare - is a typographic hyphen that
+.\" does not survive copy-paste and is not found by `man -K`.
+.TH DXPDF 1 "2026-08-10" "dxpdf" "User Commands"
+.SH NAME
+dxpdf \- convert DOCX documents to PDF
+.SH SYNOPSIS
+.B dxpdf
+.RI [ OPTIONS ]
+.I INPUT
+.SH DESCRIPTION
+.B dxpdf
+converts a Word document in Office Open XML format
+.RI ( .docx )
+to PDF. It reads
+.IR INPUT ,
+lays the document out using the fonts installed on this machine, and writes a
+PDF.
+.PP
+Layout is performed by dxpdf itself and rendering by Skia; no copy of Word,
+LibreOffice, or any other office suite is involved, and nothing is sent over
+the network.
+.PP
+If no output path is given, the PDF is written beside the input with its
+extension replaced, so
+.B dxpdf report.docx
+produces
+.IR report.pdf .
+An existing file at that path is overwritten without prompting.
+.SH OPTIONS
+.TP
+.BR \-o ", " \-\-output " " \fIFILE\fR
+Write the PDF to
+.IR FILE
+instead of to the input path with a
+.I .pdf
+extension.
+.TP
+.BR \-\-image\-dpi " " \fIDPI\fR
+Resolution, in pixels per inch, that embedded raster images are resampled to.
+Higher values give crisper images and a larger PDF. The default is
+.BR 220 ,
+matching Word, and the accepted range is
+.B 1
+to
+.BR 2400 .
+A value outside that range is rejected rather than clamped, so that a mistyped
+figure is reported instead of silently producing an unreadable document.
+.TP
+.BR \-h ", " \-\-help
+Print a summary of these options and exit.
+.TP
+.BR \-V ", " \-\-version
+Print the version and exit.
+.SH EXIT STATUS
+.TP
+.B 0
+The document was converted and written.
+.TP
+.B 1
+Conversion failed. A description of the failure is printed to standard error,
+prefixed with
+.BR "error: " .
+.SH ENVIRONMENT
+.TP
+.B RUST_LOG
+Controls diagnostic logging, which goes to standard error. The default is
+.BR warn ,
+which reports document features dxpdf does not yet support.
+.B RUST_LOG=debug
+additionally prints how long each phase took and which typeface every requested
+font family resolved to \(em the first thing to look at when output uses the
+wrong font.
+.SH EXAMPLES
+.PP
+Convert a document, writing
+.IR report.pdf :
+.PP
+.RS 4
+.B dxpdf report.docx
+.RE
+.PP
+Convert to an explicit path at print resolution:
+.PP
+.RS 4
+.B dxpdf report.docx \-o /tmp/out.pdf \-\-image\-dpi 300
+.RE
+.PP
+Find out why a font looks wrong:
+.PP
+.RS 4
+.B RUST_LOG=debug dxpdf report.docx
+.RE
+.SH NOTES
+dxpdf resolves fonts through fontconfig, using the fonts installed on the
+machine it runs on, plus any fonts embedded in the document itself. A document
+that names a font this machine does not have is rendered with a substitute, and
+on a system with no fonts installed at all the resulting PDF will contain no
+readable text. Installing
+.B fonts\-liberation2
+gives metric\-compatible stand\-ins for Arial, Times New Roman, and Courier New,
+which is what most documents ask for.
+.SH SEE ALSO
+.BR fc\-list (1),
+.BR pdftotext (1)
+.PP
+Full documentation:
+.UR https://github.com/nerdy\-pro/dxpdf
+.UE
+.SH BUGS
+Report bugs at
+.UR https://github.com/nerdy\-pro/dxpdf/issues
+.UE

--- a/scripts/verify_deb.py
+++ b/scripts/verify_deb.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Verify a built dxpdf .deb is shaped the way Debian expects.
+
+The sibling of ``verify_wheel.py``, and deliberately the same shape: pure
+standard library, parsing the container formats (``ar`` + ``tar``) directly, so
+it runs on a developer's macOS box with no ``dpkg`` installed as well as inside
+the CI container.
+
+What it is guarding, in rough order of how expensive the failure is:
+
+  1. **Nothing under /usr/lib.** The crate is ``crate-type = ["rlib",
+     "cdylib"]``, so a release build also emits ``libdxpdf.so`` — the body of
+     the PyO3 extension module, with no soname, no headers and no ABI promise.
+     cargo-deb's *default* asset set sweeps up C-ABI dynamic libraries, so the
+     explicit ``assets`` list in Cargo.toml exists to keep that out of the
+     package. This proves it stayed out.
+
+  2. **No FreeType in Depends.** ``skia-safe[embed-freetype]`` static-links
+     FreeType into Skia. If that feature is ever dropped, ``dpkg-shlibdeps``
+     starts emitting ``libfreetype6`` and the package silently acquires a
+     dependency on whatever FreeType the host has — the same class of bug
+     ``verify_wheel.py`` was written for, which showed up there as "undefined
+     symbol: FT_Palette_Data_Get" on older hosts.
+
+  3. **A font package in Recommends.** dxpdf resolves fonts through fontconfig
+     at render time, so what is installed on the machine decides what the PDF
+     looks like. A bare install is not font-less — ``libfontconfig1`` pulls in
+     ``fonts-dejavu-core`` — so the symptom is not blank text but the wrong
+     face: measured on a bookworm container, a document asking for Courier New
+     got DejaVu Sans, a proportional face substituted for a monospace one.
+     Liberation is metric-compatible with the three faces most documents ask
+     for, and recommending it is a packaging decision, so it is checked here.
+
+  4. **The Policy-required furniture** — a man page for the binary (§12.1), a
+     copyright file (§12.5), a changelog (§12.7). These are what a Debian
+     reviewer looks for first.
+
+Usage::
+
+    python3 scripts/verify_deb.py target/debian/*.deb
+
+The expected version defaults to the one in ``Cargo.toml``, so CI does not have
+to extract it; pass ``--expect-version`` to override.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+# `parse_elf` is shared with the wheel checker rather than reimplemented: the
+# FreeType invariant is the same one, and it should not be possible to fix it in
+# one place and not the other. Both scripts live in this directory, which is on
+# sys.path whenever either is run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_wheel import parse_elf  # noqa: E402
+
+#: Debian architectures we publish. `all` is deliberately absent — the package
+#: contains a compiled binary and is emphatically not architecture-independent.
+KNOWN_ARCHITECTURES = {"amd64", "arm64"}
+
+#: Every path the package is allowed to contain, and each one is required.
+#: Written as an exact set rather than a subset check so that a stray file is
+#: as loud as a missing one.
+EXPECTED_PAYLOAD = {
+    "./usr/bin/dxpdf",
+    "./usr/share/man/man1/dxpdf.1.gz",
+    "./usr/share/doc/dxpdf/copyright",
+    "./usr/share/doc/dxpdf/changelog.Debian.gz",
+    "./usr/share/doc/dxpdf/README.md",
+    "./usr/share/lintian/overrides/dxpdf",
+}
+
+#: Fields Debian Policy §5.3 requires in a binary package's control file, plus
+#: the ones that make `apt show` useful.
+REQUIRED_CONTROL_FIELDS = [
+    "Package",
+    "Version",
+    "Architecture",
+    "Maintainer",
+    "Description",
+    "Section",
+    "Priority",
+    "Homepage",
+]
+
+
+class Failure(Exception):
+    """A verification failure, reported with the .deb it came from."""
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise Failure(message)
+
+
+# --------------------------------------------------------------------------
+# `ar` — the outer container. Six lines of format, so parsing it beats taking a
+# dependency on `dpkg-deb` that would confine this script to Debian hosts.
+# --------------------------------------------------------------------------
+
+
+def read_ar(path: Path) -> list[tuple[str, bytes]]:
+    """Return ``[(member_name, member_bytes), ...]`` in archive order."""
+    data = path.read_bytes()
+    check(data[:8] == b"!<arch>\n", f"{path.name} is not an ar archive")
+
+    members: list[tuple[str, bytes]] = []
+    offset = 8
+    while offset + 60 <= len(data):
+        header = data[offset : offset + 60]
+        check(header[58:60] == b"`\n", f"{path.name}: corrupt ar header at byte {offset}")
+        # Names are space-padded and conventionally terminated by `/`.
+        name = header[0:16].decode("ascii", "replace").strip().rstrip("/")
+        size = int(header[48:58].decode("ascii", "replace").strip())
+        start = offset + 60
+        members.append((name, data[start : start + size]))
+        # Members are padded to an even offset.
+        offset = start + size + (size % 2)
+    return members
+
+
+def open_tar(name: str, blob: bytes) -> tarfile.TarFile:
+    """Open a ``control.tar.*`` / ``data.tar.*`` member.
+
+    ``tarfile`` handles gzip and xz from the standard library. Zstd needs
+    Python 3.14's ``compression.zstd``, so an older interpreter gets told what
+    to do about it rather than a stack trace.
+    """
+    if name.endswith(".zst") and sys.version_info < (3, 14):
+        raise Failure(
+            f"{name} is zstd-compressed and this Python ({sys.version_info.major}."
+            f"{sys.version_info.minor}) cannot read it. Build with "
+            "`cargo deb --compress-type xz`, which is what CI uses."
+        )
+    return tarfile.open(fileobj=io.BytesIO(blob), mode="r:*")
+
+
+def parse_control(text: str) -> dict[str, str]:
+    """Parse a Debian control stanza (RFC 822-ish, with folded continuations)."""
+    fields: dict[str, str] = {}
+    key = ""
+    for line in text.splitlines():
+        if line[:1] in (" ", "\t") and key:
+            fields[key] += "\n" + line.strip()
+        elif ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            fields[key] = value.strip()
+    return fields
+
+
+def dependency_names(field: str) -> list[str]:
+    """Package names from a Depends/Recommends field, alternatives flattened.
+
+    ``libc6 (>= 2.36), fonts-liberation2 | fonts-liberation`` becomes
+    ``["libc6", "fonts-liberation2", "fonts-liberation"]``.
+    """
+    names = []
+    for clause in field.split(","):
+        for alternative in clause.split("|"):
+            name = alternative.strip().split(" ")[0].split("(")[0].strip()
+            if name:
+                names.append(name)
+    return names
+
+
+# --------------------------------------------------------------------------
+# The checks
+# --------------------------------------------------------------------------
+
+
+def verify(deb: Path, expect_version: str | None) -> None:
+    check(deb.is_file(), f"{deb} not found")
+    print(f"verifying {deb.name}")
+
+    members = read_ar(deb)
+    names = [name for name, _ in members]
+    check(
+        len(names) >= 3 and names[0] == "debian-binary",
+        f"expected debian-binary first, got {names}",
+    )
+    check(
+        names[1].startswith("control.tar") and names[2].startswith("data.tar"),
+        f"expected control.tar.* then data.tar.*, got {names[1:3]}",
+    )
+    blobs = dict(members)
+    check(
+        blobs["debian-binary"] == b"2.0\n",
+        f"unexpected deb format version {blobs['debian-binary']!r}",
+    )
+
+    control_tar = open_tar(names[1], blobs[names[1]])
+    data_tar = open_tar(names[2], blobs[names[2]])
+
+    _verify_control(control_tar, expect_version)
+    _verify_payload(data_tar)
+    _verify_md5sums(control_tar, data_tar)
+    print(f"OK: {deb.name}")
+
+
+def _verify_control(control_tar: tarfile.TarFile, expect_version: str | None) -> None:
+    entry = control_tar.extractfile("./control")
+    check(entry is not None, "control.tar has no ./control")
+    fields = parse_control(entry.read().decode("utf-8"))
+
+    missing = [f for f in REQUIRED_CONTROL_FIELDS if not fields.get(f)]
+    check(not missing, f"control is missing required field(s): {missing}")
+
+    check(fields["Package"] == "dxpdf", f"Package is {fields['Package']!r}, expected 'dxpdf'")
+    check(
+        fields["Architecture"] in KNOWN_ARCHITECTURES,
+        f"Architecture {fields['Architecture']!r} is not one of {sorted(KNOWN_ARCHITECTURES)}",
+    )
+    if expect_version:
+        # cargo-deb appends a Debian revision, so 0.4.0 becomes 0.4.0-1.
+        check(
+            fields["Version"].split("-")[0] == expect_version,
+            f"Version is {fields['Version']!r}, expected upstream {expect_version}",
+        )
+    check(
+        "@" in fields["Maintainer"] and "<" in fields["Maintainer"],
+        f"Maintainer {fields['Maintainer']!r} is not a 'Name <address>' pair",
+    )
+    # A one-line Description is legal but useless in `apt show`; the extended
+    # body is what a user reads before installing.
+    check(
+        "\n" in fields["Description"],
+        "Description has no extended body (set `extended-description` in Cargo.toml)",
+    )
+    print(f"  {fields['Package']} {fields['Version']} {fields['Architecture']}")
+
+    depends = dependency_names(fields.get("Depends", ""))
+    print(f"  Depends ({len(depends)}): {', '.join(depends)}")
+    freetype = [d for d in depends if "freetype" in d]
+    check(
+        not freetype,
+        f"Depends names {freetype} — `embed-freetype` should have "
+        "static-linked FreeType into Skia. See this script's module docstring.",
+    )
+    for required in ("libc6", "libfontconfig1"):
+        check(
+            required in depends,
+            f"Depends does not name {required}; `depends = \"$auto\"` may not have run "
+            "(dpkg-shlibdeps only works on a Debian host)",
+        )
+
+    recommends = dependency_names(fields.get("Recommends", ""))
+    check(
+        any(d.startswith("fonts-") for d in recommends),
+        f"Recommends names no font package (got {recommends}) — on a minimal "
+        "Debian install the converter would emit text-free PDFs",
+    )
+    print(f"  Recommends: {', '.join(recommends)}")
+
+
+def _verify_payload(data_tar: tarfile.TarFile) -> None:
+    entries = {m.name: m for m in data_tar.getmembers() if not m.isdir()}
+
+    check(
+        set(entries) == EXPECTED_PAYLOAD,
+        "payload mismatch:\n"
+        f"    unexpected: {sorted(set(entries) - EXPECTED_PAYLOAD)}\n"
+        f"    missing:    {sorted(EXPECTED_PAYLOAD - set(entries))}",
+    )
+    # Redundant with the exact-set check above while EXPECTED_PAYLOAD stays as
+    # it is, but it is the assertion that must survive someone adding a file to
+    # that set for an unrelated reason.
+    stray = [name for name in entries if name.startswith("./usr/lib")]
+    check(not stray, f"package ships {stray} under /usr/lib — the cdylib must not be packaged")
+
+    binary = entries["./usr/bin/dxpdf"]
+    check(binary.isfile(), "./usr/bin/dxpdf is not a regular file")
+    check(binary.mode & 0o777 == 0o755, f"./usr/bin/dxpdf has mode {binary.mode:o}, expected 755")
+
+    with tempfile.TemporaryDirectory() as td:
+        extracted = Path(td) / "dxpdf"
+        source = data_tar.extractfile(binary)
+        check(source is not None, "cannot read ./usr/bin/dxpdf out of data.tar")
+        extracted.write_bytes(source.read())
+
+        if extracted.read_bytes()[:4] != b"\x7fELF":
+            # Building on macOS produces a Mach-O binary inside a Debian
+            # container format. Everything above still holds; the linkage
+            # checks below do not apply.
+            print("  note: binary is not ELF (cross-format build) — skipping linkage checks")
+            return
+
+        needed, undef_ft = parse_elf(extracted)
+        print(f"  DT_NEEDED ({len(needed)}): {', '.join(needed)}")
+        ft_needed = [n for n in needed if "freetype" in n.lower()]
+        check(not ft_needed, f"/usr/bin/dxpdf directly links {ft_needed}")
+        check(
+            not undef_ft,
+            f"/usr/bin/dxpdf has {len(undef_ft)} unresolved FT_* symbols: "
+            f"{', '.join(undef_ft[:5])}",
+        )
+
+
+def _verify_md5sums(control_tar: tarfile.TarFile, data_tar: tarfile.TarFile) -> None:
+    """Check `md5sums` if there is one — a *stale* one is worse than none.
+
+    cargo-deb 3.6.2 writes no `md5sums` at all: the control archive holds only
+    `./control`. That costs `dpkg --verify` and `debsums` their ability to say
+    whether an installed file has been altered, and lintian notes it as
+    `no-md5sums-control-file` — at severity *info*, so it is not something the
+    package is failing to do so much as something it is not doing. Fixing it
+    means repacking the archive after cargo-deb, which is a lot of machinery
+    for an info-level tag, so this is a soft check rather than a hard one: it
+    reports the absence and verifies the contents if a future cargo-deb starts
+    emitting them.
+    """
+    names = {m.name.lstrip("./") for m in control_tar.getmembers()}
+    if "md5sums" not in names:
+        print("  note: no md5sums in control.tar (cargo-deb does not write one)")
+        return
+
+    entry = control_tar.extractfile("./md5sums")
+    check(entry is not None, "control.tar lists md5sums but it cannot be read")
+    recorded = {}
+    for line in entry.read().decode("utf-8").splitlines():
+        digest, _, path = line.partition("  ")
+        recorded[f"./{path}"] = digest
+
+    payload = {m.name for m in data_tar.getmembers() if m.isfile()}
+    check(
+        set(recorded) == payload,
+        f"md5sums does not cover the payload:\n"
+        f"    unlisted: {sorted(payload - set(recorded))}\n"
+        f"    phantom:  {sorted(set(recorded) - payload)}",
+    )
+    for name, digest in recorded.items():
+        member = data_tar.extractfile(name)
+        check(member is not None, f"md5sums lists {name}, which is not readable")
+        actual = hashlib.md5(member.read()).hexdigest()
+        check(actual == digest, f"md5sums for {name} is {digest}, actual {actual}")
+    print(f"  md5sums: {len(recorded)} file(s), all matching")
+
+
+def manifest_version() -> str | None:
+    """The crate version from Cargo.toml, or None if it cannot be read.
+
+    ``tomllib`` is standard library from Python 3.11, which is what bookworm
+    ships; on anything older this returns None and the version check is skipped
+    rather than the whole run failing over a default.
+    """
+    try:
+        import tomllib
+    except ImportError:
+        return None
+    manifest = Path(__file__).resolve().parent.parent / "Cargo.toml"
+    try:
+        with open(manifest, "rb") as f:
+            return tomllib.load(f)["package"]["version"]
+    except (OSError, KeyError):
+        return None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("debs", type=Path, nargs="+", help="path(s) to .deb files")
+    ap.add_argument(
+        "--expect-version",
+        default=manifest_version(),
+        help="upstream version to require (default: the version in Cargo.toml)",
+    )
+    args = ap.parse_args()
+    if not args.expect_version:
+        print("note: could not read a version from Cargo.toml; not checking Version")
+
+    failures = 0
+    for deb in args.debs:
+        try:
+            verify(deb, args.expect_version)
+        except Failure as exc:
+            print(f"FAIL: {deb.name}: {exc}", file=sys.stderr)
+            failures += 1
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,11 @@ use dxpdf::{RenderOptions, DEFAULT_IMAGE_DPI};
 #[command(
     name = "dxpdf",
     about = "DOCX files to PDF converter",
+    // Without this, clap defines no `--version` at all. A packaged CLI is
+    // expected to answer it — it is the first thing a user runs after `apt
+    // install`, the first thing a bug report quotes, and what the Debian
+    // install test in CI uses as its smoke check.
+    version,
     allow_negative_numbers = true
 )]
 struct Cli {

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -223,6 +223,43 @@ fn debian_changelog_leads_with_the_current_version() {
 }
 
 #[test]
+fn lintian_overrides_name_tags_without_context() {
+    // Lintian prints a tag as `dxpdf: embedded-library expat [usr/bin/dxpdf]`,
+    // and pasting that straight back in is the obvious way to write an
+    // override — but the context is a property of one build. An override
+    // carrying it matched exactly on arm64 and came back as
+    // `mismatched-override` on amd64, which failed the release. A bare tag name
+    // matches every instance, and an override matching nothing is only a note.
+    let path = repo_root().join("debian/dxpdf.lintian-overrides");
+    let overrides = std::fs::read_to_string(&path).expect("lintian overrides file is missing");
+
+    for (n, line) in overrides.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let tag = line.strip_prefix("dxpdf: ").unwrap_or_else(|| {
+            panic!(
+                "{}:{} is not `dxpdf: <tag>`: {line:?}",
+                path.display(),
+                n + 1
+            )
+        });
+        assert!(
+            !tag.is_empty()
+                && tag
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+            "{}:{} carries context after the tag name: {line:?} — write `dxpdf: {}` alone, \
+             or it will mismatch on another architecture",
+            path.display(),
+            n + 1,
+            tag.split_whitespace().next().unwrap_or(tag),
+        );
+    }
+}
+
+#[test]
 fn verify_deb_script_is_executable_python() {
     // CI runs this as `python3 scripts/verify_deb.py`; a missing file there
     // fails the packaging job several minutes into a Skia build.

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -1,0 +1,234 @@
+//! Packaging invariants for the Debian package (issue #92).
+//!
+//! The `.deb` itself can only be built and inspected on a Debian host — that
+//! job belongs to `scripts/verify_deb.py` and the container jobs in CI. What
+//! *can* be checked on every platform, in `cargo test --all`, is the source
+//! material those jobs consume: the man page and the `[package.metadata.deb]`
+//! table. Both are the kind of thing that rots silently — a new CLI flag or a
+//! renamed file breaks the package at release time, weeks after the change that
+//! caused it. These tests move that failure to the commit that causes it.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The man page as plain text, with roff's escaping removed.
+///
+/// A man page writes a literal hyphen as `\-` (an unescaped `-` is a
+/// typographic hyphen that breaks copy-paste and `man -K` search), so
+/// `\-\-image\-dpi` is the correct spelling of `--image-dpi` on disk. Dropping
+/// every backslash is enough to search for flag names without teaching this
+/// test the rest of roff.
+fn man_page_text() -> String {
+    let path = repo_root().join("man/dxpdf.1");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{} is missing or unreadable: {e}", path.display()));
+    raw.replace('\\', "")
+}
+
+/// Every flag `dxpdf --help` advertises, as it appears in the help text:
+/// long flags (`--image-dpi`) and short ones (`-o`).
+fn flags_from_help() -> Vec<String> {
+    let out = Command::new(env!("CARGO_BIN_EXE_dxpdf"))
+        .arg("--help")
+        .output()
+        .expect("failed to run the dxpdf binary");
+    assert!(
+        out.status.success(),
+        "`dxpdf --help` exited with {:?}",
+        out.status
+    );
+    let help = String::from_utf8(out.stdout).expect("--help output is not UTF-8");
+
+    let mut flags = Vec::new();
+    let bytes: Vec<char> = help.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        // A flag starts at a `-` that is not preceded by a word character, so
+        // the hyphen inside `image-dpi` doesn't start a second match.
+        let boundary = i == 0 || !bytes[i - 1].is_alphanumeric() && bytes[i - 1] != '-';
+        if bytes[i] == '-' && boundary {
+            let start = i;
+            i += 1;
+            if i < bytes.len() && bytes[i] == '-' {
+                i += 1;
+            }
+            let name_start = i;
+            while i < bytes.len() && (bytes[i].is_alphanumeric() || bytes[i] == '-') {
+                i += 1;
+            }
+            if i > name_start {
+                let flag: String = bytes[start..i].iter().collect();
+                if !flags.contains(&flag) {
+                    flags.push(flag);
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    flags
+}
+
+#[test]
+fn man_page_documents_every_cli_flag() {
+    let man = man_page_text();
+    let flags = flags_from_help();
+
+    // A guard on the guard: if the scrape ever returns nothing, the assertion
+    // loop below passes vacuously and the test stops testing anything.
+    assert!(
+        flags.len() >= 4,
+        "expected at least -o/--output, --image-dpi, --help, --version from `--help`, got {flags:?}"
+    );
+
+    let missing: Vec<&String> = flags.iter().filter(|f| !man.contains(f.as_str())).collect();
+    assert!(
+        missing.is_empty(),
+        "man/dxpdf.1 does not document {missing:?} — `dxpdf --help` advertises {flags:?}"
+    );
+}
+
+#[test]
+fn man_page_states_the_real_dpi_bounds() {
+    let man = man_page_text();
+    // `MIN_CLI_IMAGE_DPI` / `MAX_CLI_IMAGE_DPI` / `DEFAULT_IMAGE_DPI`. The CLI
+    // *rejects* out-of-range values rather than clamping them (see the comment
+    // on `parse_image_dpi` in src/main.rs), so the documented range is the
+    // difference between a working invocation and an error.
+    for bound in ["220", "2400"] {
+        assert!(
+            man.contains(bound),
+            "man/dxpdf.1 never mentions {bound}, so it cannot be stating the --image-dpi range"
+        );
+    }
+}
+
+#[test]
+fn deb_metadata_is_complete_and_points_at_files_that_exist() {
+    let manifest = std::fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
+    // `Table`, not `Value`: `FromStr for Value` parses a bare TOML *value*, so a
+    // whole manifest comes back as "unexpected content" the moment it reaches
+    // the newline after `[package]` (which it read as an inline array).
+    let manifest: toml::Table = manifest.parse().expect("Cargo.toml is not valid TOML");
+
+    let deb = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("deb"))
+        .expect("Cargo.toml has no [package.metadata.deb] — `cargo deb` cannot build a package");
+
+    // `maintainer` has no default: Cargo.toml declares no `authors`, so
+    // cargo-deb has nothing to fall back on and refuses to build without it.
+    for field in ["maintainer", "section", "priority", "assets", "changelog"] {
+        assert!(
+            deb.get(field).is_some(),
+            "[package.metadata.deb] is missing `{field}`"
+        );
+    }
+
+    // `changelog` and `license-file` are paths cargo-deb reads directly rather
+    // than through `assets`, so the asset loop below never sees them.
+    for key in ["changelog", "license-file"] {
+        let path = match &deb[key] {
+            toml::Value::String(s) => s.clone(),
+            // `license-file = ["LICENSE", "0"]` — path first, lines-to-skip second.
+            toml::Value::Array(a) => a[0].as_str().unwrap_or_default().to_string(),
+            other => panic!("[package.metadata.deb] {key} has unexpected type {other:?}"),
+        };
+        assert!(
+            repo_root().join(&path).is_file(),
+            "[package.metadata.deb] {key} points at `{path}`, which does not exist"
+        );
+    }
+
+    let assets = deb["assets"].as_array().expect("`assets` must be an array");
+    let mut sources = Vec::new();
+    for asset in assets {
+        let row = asset
+            .as_array()
+            .expect("each asset is [source, dest, mode]");
+        let source = row[0].as_str().expect("asset source must be a string");
+        sources.push(source.to_string());
+
+        // `target/…` is a build product and only exists after `cargo build
+        // --release`; everything else is committed and must be there now.
+        if !source.starts_with("target/") {
+            let path = repo_root().join(source);
+            assert!(
+                path.is_file(),
+                "[package.metadata.deb] ships `{source}`, which does not exist"
+            );
+        }
+    }
+
+    // The binary and the man page are what make this a usable package: Debian
+    // Policy §12.1 requires a manual page for every program in /usr/bin.
+    assert!(
+        sources.iter().any(|s| s == "target/release/dxpdf"),
+        "the package must ship the dxpdf binary, got {sources:?}"
+    );
+    let man_dest = assets
+        .iter()
+        .find(|a| a[0].as_str() == Some("man/dxpdf.1"))
+        .map(|a| a[1].as_str().unwrap_or_default().to_string())
+        .expect("the package must ship man/dxpdf.1");
+    assert_eq!(
+        man_dest, "usr/share/man/man1/",
+        "the man page must land in section 1's directory or `man dxpdf` will not find it"
+    );
+
+    // The crate is `crate-type = ["rlib", "cdylib"]`, so `cargo build
+    // --release` also emits `libdxpdf.so` — the body of the PyO3 extension
+    // module, with no soname, no headers and no ABI promise. cargo-deb's
+    // *default* asset set picks up C-ABI dynamic libraries, so the explicit
+    // list above exists to keep that out of /usr/lib. `verify_deb.py` proves
+    // it stayed out; this proves nobody added it back by hand.
+    assert!(
+        !sources.iter().any(|s| s.contains("libdxpdf")),
+        "the cdylib must not be packaged: {sources:?}"
+    );
+}
+
+#[test]
+fn debian_changelog_leads_with_the_current_version() {
+    // `apt changelog dxpdf` shows this, and a changelog whose newest entry is
+    // for a version nobody is running is worse than none. Nothing generates
+    // this file, so the only thing keeping it current is this assertion firing
+    // on the commit that bumps the version.
+    let changelog = std::fs::read_to_string(repo_root().join("debian/changelog"))
+        .expect("debian/changelog is missing — [package.metadata.deb] points at it");
+    let first = changelog.lines().next().unwrap_or_default();
+
+    // `dxpdf (0.4.0-1) unstable; urgency=medium`
+    let entry = first
+        .split_once('(')
+        .and_then(|(name, rest)| rest.split_once(')').map(|(v, _)| (name.trim(), v)))
+        .unwrap_or_else(|| panic!("first changelog line is not a Debian entry header: {first:?}"));
+    assert_eq!(entry.0, "dxpdf", "changelog names the wrong package");
+
+    let upstream = entry.1.split('-').next().unwrap();
+    assert_eq!(
+        upstream,
+        env!("CARGO_PKG_VERSION"),
+        "debian/changelog's newest entry is {:?}, but the crate is at {} — \
+         add an entry (`dch -v {}-1`) before releasing",
+        entry.1,
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_VERSION"),
+    );
+}
+
+#[test]
+fn verify_deb_script_is_executable_python() {
+    // CI runs this as `python3 scripts/verify_deb.py`; a missing file there
+    // fails the packaging job several minutes into a Skia build.
+    let script = repo_root().join("scripts/verify_deb.py");
+    assert!(
+        Path::new(&script).is_file(),
+        "scripts/verify_deb.py is missing — CI's packaging job calls it"
+    );
+}


### PR DESCRIPTION
- Implemented Debian package creation using `cargo deb`, including necessary metadata in `Cargo.toml`.
- Added `debian/changelog` and `debian/dxpdf.lintian-overrides` for package compliance.
- Created a man page for `dxpdf` to meet Debian Policy requirements.
- Introduced `scripts/verify_deb.py` to validate the structure and dependencies of the built .deb package.
- Enhanced `README.md` with installation instructions for Debian/Ubuntu users.
- Added tests in `tests/packaging.rs` to ensure packaging invariants and metadata correctness.
- Updated `Cargo.lock` to include the `toml` dependency for parsing.
- Modified `src/main.rs` to include version information for the CLI.