### PR TITLE
fix: safe UTF-8 prefix matching in ToC style detection and tolerant parsing for duplicate table cell properties

### DIFF
--- a/src/docx/parse/properties/schema/measure.rs
+++ b/src/docx/parse/properties/schema/measure.rs
@@ -64,6 +64,25 @@ where
     Ok(measure)
 }
 
+/// Deserializes a list of `TableMeasureXml` elements while verifying that no explicit
+/// measurement value is negative.
+pub(crate) fn deserialize_vec_nonnegative_table_measure<'de, D>(
+    deserializer: D,
+) -> Result<Vec<TableMeasureXml>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let measures = Vec::<TableMeasureXml>::deserialize(deserializer)?;
+    for value in &measures {
+        if value.w.as_ref().is_some_and(IntegerMeasure::is_negative) {
+            return Err(serde::de::Error::custom(
+                "negative value is not valid for this OOXML table measurement",
+            ));
+        }
+    }
+    Ok(measures)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/docx/parse/properties/schema/table.rs
+++ b/src/docx/parse/properties/schema/table.rs
@@ -21,7 +21,10 @@ use crate::docx::parse::primitives::{last_toggle, OnOff};
 use super::border::{TableBordersXml, TableCellBordersXml};
 use super::cnf_style::CnfStyleXml;
 use super::insets::EdgeInsetsTwipsXml;
-use super::measure::{deserialize_optional_nonnegative_table_measure, TableMeasureXml};
+use super::measure::{
+    deserialize_optional_nonnegative_table_measure, deserialize_vec_nonnegative_table_measure,
+    TableMeasureXml,
+};
 use super::shading::ShdXml;
 
 // ── tblPr ───────────────────────────────────────────────────────────────
@@ -382,32 +385,37 @@ impl From<TrPrXml> for TableRowProperties {
 
 // ── tcPr ───────────────────────────────────────────────────────────────
 
+/// Table cell property bag (§17.4.70 `w:tcPr`).
+///
+/// Child properties are deserialized as `Vec<T>` to tolerate duplicate XML elements
+/// (such as repeated `<w:tcMar>` or `<w:tcBorders>` emitted by Word/LibreOffice)
+/// without failing deserialization. Per OOXML §17.7.2, the last occurrence wins.
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct TcPrXml {
     #[serde(rename = "tcBorders", default)]
-    tc_borders: Option<TableCellBordersXml>,
+    tc_borders: Vec<TableCellBordersXml>,
     #[serde(rename = "tcMar", default)]
-    tc_mar: Option<EdgeInsetsTwipsXml>,
+    tc_mar: Vec<EdgeInsetsTwipsXml>,
     #[serde(
         rename = "tcW",
         default,
-        deserialize_with = "deserialize_optional_nonnegative_table_measure"
+        deserialize_with = "deserialize_vec_nonnegative_table_measure"
     )]
-    tc_w: Option<TableMeasureXml>,
+    tc_w: Vec<TableMeasureXml>,
     #[serde(rename = "shd", default)]
-    shd: Option<ShdXml>,
+    shd: Vec<ShdXml>,
     #[serde(rename = "vAlign", default)]
-    v_align: Option<ValAttr<StVerticalJc>>,
+    v_align: Vec<ValAttr<StVerticalJc>>,
     #[serde(rename = "vMerge", default)]
-    v_merge: Option<VMergeXml>,
+    v_merge: Vec<VMergeXml>,
     #[serde(rename = "gridSpan", default)]
-    grid_span: Option<ValAttr<u32>>,
+    grid_span: Vec<ValAttr<u32>>,
     #[serde(rename = "textDirection", default)]
-    text_direction: Option<ValAttr<StTextDirection>>,
+    text_direction: Vec<ValAttr<StTextDirection>>,
     #[serde(rename = "noWrap", default)]
     no_wrap: Vec<OnOff>,
     #[serde(rename = "cnfStyle", default)]
-    cnf_style: Option<CnfStyleXml>,
+    cnf_style: Vec<CnfStyleXml>,
 }
 
 /// `<w:vMerge/>` — absent `@val` means "continue"; `@val="restart"` starts a
@@ -437,20 +445,24 @@ impl From<VMergeXml> for VerticalMerge {
 impl From<TcPrXml> for TableCellProperties {
     fn from(x: TcPrXml) -> Self {
         Self {
-            width: x.tc_w.map(Into::into),
-            borders: x.tc_borders.map(Into::into),
-            shading: x.shd.map(Into::into),
-            margins: x.tc_mar.map(Into::into),
+            width: x.tc_w.into_iter().last().map(Into::into),
+            borders: x.tc_borders.into_iter().last().map(Into::into),
+            shading: x.shd.into_iter().last().map(Into::into),
+            margins: x.tc_mar.into_iter().last().map(Into::into),
             vertical_align: x
                 .v_align
+                .into_iter()
+                .last()
                 .map(|v| crate::docx::model::CellVerticalAlign::from(v.val)),
-            vertical_merge: x.v_merge.map(Into::into),
-            grid_span: x.grid_span.map(|v| v.val),
+            vertical_merge: x.v_merge.into_iter().last().map(Into::into),
+            grid_span: x.grid_span.into_iter().last().map(|v| v.val),
             text_direction: x
                 .text_direction
+                .into_iter()
+                .last()
                 .map(|v| crate::docx::model::TextDirection::from(v.val)),
             no_wrap: last_toggle(x.no_wrap),
-            cnf_style: x.cnf_style.map(CnfStyle::from),
+            cnf_style: x.cnf_style.into_iter().last().map(CnfStyle::from),
         }
     }
 }
@@ -790,5 +802,17 @@ mod tests {
             .unwrap()
             .into();
         assert!(ex.cell_spacing.is_some(), "tblPrEx §17.4.41");
+    }
+
+    #[test]
+    fn tc_pr_duplicate_tc_mar_does_not_fail() {
+        let tc = parse_tc_pr(
+            r#"<tcPr>
+                <tcMar><top w="100" type="dxa"/></tcMar>
+                <tcMar><bottom w="200" type="dxa"/></tcMar>
+            </tcPr>"#,
+        );
+        assert!(tc.margins.is_some());
+        assert_eq!(tc.margins.unwrap().bottom.map(|d| d.raw()), Some(200));
     }
 }

--- a/src/render/resolve/styles.rs
+++ b/src/render/resolve/styles.rs
@@ -510,7 +510,7 @@ mod tests {
             "toc 1x",
             "table of contents",
             "TOCustom", // the false positive the old styleId prefix test hit
-            // Multi-byte non-ASCII UTF-8 style names where byte index 4 falls inside a code point:
+            // Multi-byte non-ASCII UTF-8 style names (including cases where byte index 4 is not a char boundary):
             "Éléments de style",
             "Заголовок 1",
             "引用",

--- a/src/render/resolve/styles.rs
+++ b/src/render/resolve/styles.rs
@@ -38,13 +38,14 @@ pub struct ResolvedStyle {
 /// Deliberately excludes `TOC Heading` (the heading *above* a ToC, not an
 /// entry) and `toc` with no level, neither of which is an entry style.
 fn is_toc_entry_name(name: &str) -> bool {
-    // OOXML style names compare case-insensitively.
-    let rest = if name.len() >= 4 && name[..4].eq_ignore_ascii_case("toc ") {
-        &name[4..]
-    } else {
-        return false;
-    };
-    matches!(rest.parse::<u8>(), Ok(1..=9))
+    // OOXML style names compare case-insensitively. Safely check prefix without
+    // panicking when a localized style name contains multi-byte UTF-8 characters.
+    if let Some(prefix) = name.get(..4) {
+        if prefix.eq_ignore_ascii_case("toc ") {
+            return matches!(name[4..].parse::<u8>(), Ok(1..=9));
+        }
+    }
+    false
 }
 
 /// Resolve all styles in the stylesheet by walking `basedOn` chains.
@@ -509,6 +510,11 @@ mod tests {
             "toc 1x",
             "table of contents",
             "TOCustom", // the false positive the old styleId prefix test hit
+            // Multi-byte non-ASCII UTF-8 style names where byte index 4 falls inside a code point:
+            "Éléments de style",
+            "Заголовок 1",
+            "引用",
+            "Título 1",
             "",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

This PR addresses two document conversion issues encountered when converting DOCX files to PDF:

### 1. Safe UTF-8 Prefix Matching in `is_toc_entry_name`
- **Issue**: In `src/render/resolve/styles.rs`, `is_toc_entry_name` checked `name.len() >= 4` and then directly sliced `&name[..4]`. When a style name contains non-ASCII multi-byte UTF-8 characters (e.g. localized or custom style names), byte index 4 can fall inside a multi-byte code point, causing a panic (`byte index 4 is not a char boundary`).
- **Fix**: Replaced byte slicing with safe subslice extraction via `name.get(..4)`. Added unit tests covering multi-byte UTF-8 style names where index 4 falls across code point boundaries.

### 2. Tolerant Parsing for Duplicate Table Cell Property Elements
- **Issue**: In `src/docx/parse/properties/schema/table.rs`, `TcPrXml` defined properties like `tcMar`, `tcBorders`, `tcW`, `shd`, etc., as single optional fields (`Option<T>`). When DOCX documents produced by Word or LibreOffice contain duplicate XML elements (such as repeated `<w:tcMar>` tags within `<w:tcPr>`), deserialization failed with `duplicate field \`tcMar\``.
- **Fix**: Updated `TcPrXml` fields to `Vec<T>` and applied OOXML §17.7.2 semantics where the last occurrence takes precedence (`.into_iter().last()`). Added `deserialize_vec_nonnegative_table_measure` in `src/docx/parse/properties/schema/measure.rs` to validate that repeated measurement elements remain non-negative, along with unit tests verifying duplicate tag parsing.

## Quality Checks
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all` / `cargo test --lib` (1,888 tests passing)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] `cargo build --no-default-features`