### PR TITLE
docs: relocate plans/open-work.md into code, AGENTS.md and the tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,27 @@ The converter follows a **parse → resolve → layout → (subset) → paint** 
 
 ## OOXML Reference
 
-**`docs/` — behavior.** How the engine works today, and WHY it makes those choices, which is generally not re-derivable from the source. Consult the relevant page before changing layout behavior, and update it in the same change when you change behavior it describes. A page here stays valid as long as the behavior does.
+**There is no reference directory.** `docs/` was removed deliberately, page by page: a prose page describing behaviour drifts from the behaviour, and the second copy is the one that goes stale. WHY the engine makes a choice — which is generally not re-derivable from the source — belongs in the **module doc or the comment at the site that makes the choice**, where it is next to the thing it explains and moves when that moves. The "No doc yet" list below is now simply the entry-point list.
 
-`docs/` is the only reference directory in the repo. Working notes — designs, profiling analyses, branch reviews — are kept **local and uncommitted** (`/plans/`, gitignored), because they describe a point in time rather than current behaviour. Nothing tracked may link to them, and no code comment may cite them: a fresh clone does not have them. Anything that must outlive the work belongs in `docs/`, or in the code it describes.
+Working notes — designs, profiling analyses, branch reviews — are kept **local and uncommitted** (`/plans/`, gitignored), because they describe a point in time rather than current behaviour. Nothing tracked may link to them, and no code comment may cite them: a fresh clone does not have them. That cuts both ways, and it is the rule most easily broken by accident: **anything in `/plans/` that must outlive the work has to be moved out before the file is deleted** — into the code it describes, into this file, or into a GitHub issue. A note that exists only there is one `rm -rf` from gone, and nothing will warn you.
 
 ### Known-unimplemented work
 
 Open engineering units are tracked as GitHub issues, not here — this file goes stale the moment one closes. Everything that is *not* a tracked unit is recorded where it applies: each ambiguity ECMA-376 cannot settle is stated in a comment at the site that makes the choice, saying what the choice is, why the spec does not decide it, and what evidence would. Grep for "Word reference render" to find them. Where a capability boundary is deliberate, the code says so at the boundary rather than deferring to the tracker — `SubsetOutcome::VariableInstanceNotBaked` states why a variable instance cannot be baked into embedded PDF bytes and names its two candidate routes; `register_embedded` states which faces of an embedded collection a given platform will open; `src/render/fonts/request.rs` states why `Toggle::Off` and `Toggle::Absent` select the same face today. One larger question is a decision rather than a gap: whether to take on a CLDR/ICU dependency for the i18n gaps tracked in issue #124.
+
+### Decided — do not redo
+
+Work deliberately *not* done. It is here rather than at a site because there is no site: no code was written, so a comment has nowhere to live. Reopen any of it with evidence, not with reasoning — each was closed against a measurement.
+
+**Rejected optimisations.** Layout is 1–3.5 ms on 25 of 33 corpus documents, and that is the budget every one of these competed for: font-family interning · `Vec::with_capacity` seeding in the hot builders · `format!` per footnote number (which would also have cost an `itoa` dependency) · the per-run `RunProperties` clone. Reopen only with a profile showing layout is the bottleneck for the workload in question. `PTabLeader`'s pass-through enum is a separate "no": a distinct per-spec-type enum is what the spec-faithful ADT convention prescribes, so the extra layer is intentional — unlike `PTabAlignment`, which earns its enum by driving distinct layout math.
+
+**Investigated and rejected.** Sharing `PackageContents` parts to remove the last package→media image copy: a parse-only probe peaks at 135 MB on the largest corpus document against 217 MB for the full render, so that duplicate never sets the peak. The keepNext double-layout and the floating-table double-measure: both measured in microseconds, and not worth the pagination risk.
+
+**Inherited § citations are suspect until checked.** The retired findings cited `a:bodyPr/@vertOverflow` as §20.1.10.85, but [`drawing.rs`](src/model/types/drawing.rs) already annotates §20.1.10.85 as `ST_TextWrappingType` — the `wrap` attribute. Both cannot be right, and the conflict was resolved by *not* citing the disputed number: the code names the attribute (`a:bodyPr/@vertOverflow`, `ST_TextVertOverflowType`), which is unambiguous. Confirm any § against the spec before adding it, and never inherit one from a document.
+
+**Worth knowing.** The `textlayout` feature costs binary size — the release binary is 15.9 → 28.2 MB (+77%) for ICU plus SkShaper/HarfBuzz. The same Skia build independently improved PDF font embedding: corpus output fell 28.98 → 27.22 MB (−6.1%), one document by −88%. That is Skia's PDF backend, not this engine's subset pass; don't attribute it here.
+
+**When a fix is written from the symptom rather than the spec, it tends to be wrong.** The last attempt to do so prescribed *clipping text Word draws* (`@vertOverflow`). Three times a written plan was itself wrong — the MCE ADT, the `bar` tab's semantics, and a locale unit's premise that its ambiguity blocked implementation — and writing the tests from the spec first is what exposed it each time. Treat any plan, including one in this file, as a starting point to verify rather than a specification to implement.
 
 **No doc yet** — start from the module docs at these entry points: character spacing and distributed alignment (`src/render/spacing.rs` — §17.3.2.35 and §17.3.1.13 share one unit, the UAX #29 grapheme cluster; the module doc says why it is that and not a shaped cluster), color-emoji pipeline (`src/render/emoji/mod.rs`), parse/serde schemas (`src/docx/parse/`, the `XxxXml` → domain seam), text shaping & fragments (`src/render/layout/fragment/`), per-glyph font fallback (`src/render/layout/fragment/fallback.rs` — why the fallback is carried as a name and not a resolved face, and why the early-out is load-bearing), paint & PDF emission (`src/render/painter.rs`), EMF images (`src/render/emf.rs`), numbering & list labels (`src/docx/parse/numbering.rs`, `src/render/layout/build/list_label.rs`), VML fallback (`src/docx/parse/vml/`).
 
@@ -145,6 +159,12 @@ docker run --rm -v "$PWD:/w" -w /w debian:12-slim bash -c '
 ```
 
 Two things that are not obvious from the files. The `assets` list is explicit because cargo-deb's default set also picks up C-ABI dynamic libraries, and `crate-type = ["rlib", "cdylib"]` means a release build emits `libdxpdf.so` — the PyO3 extension body, which has no business in `/usr/lib`. And when testing an install in a Debian *container*, delete `/etc/dpkg/dpkg.cfg.d/docker` first: it sets `path-exclude /usr/share/man/*`, so dpkg drops the man page and the test appears to prove the package has none.
+
+**How a change is built here.** Three conventions that the CI commands below do not enforce and that reviewers assume have happened:
+
+- **Tests written from the spec, first, and watched fail.** Not written against current output, which only pins the bug. Where a change touches uncovered code, the characterization tests land first as their own commit.
+- **A mutation check on every new test.** A test written alongside its implementation passes on the first run, which proves nothing. Break the implementation deliberately and confirm the right tests fail — if none does, the test is decoration.
+- **Pixel-diff any change that moves geometry**, across `test-files/` + `test-cases/`, and *explain* every diff rather than merely observing it. A document that changes is either the fix working or a regression, and only reading the pixels says which.
 
 **Before handing work back**, run what CI runs (`.github/workflows/ci.yml`):
 

--- a/src/docx/parse/vml/color.rs
+++ b/src/docx/parse/vml/color.rs
@@ -8,6 +8,14 @@ use crate::docx::model::*;
 /// optional (an unparseable `fillcolor` simply means "no color"), so this
 /// mirrors the sibling `parse_style`/`parse_formula`/`parse_length` helpers
 /// rather than raising a document-fatal error.
+///
+/// **Two §14.1.2.1 forms are deliberately not modelled**, and both degrade to
+/// "no color" here: three-digit hex (`#f00`), and the two-token commands that
+/// modify a colour (`red lighten(128)`, `fill darken(64)`). Adding them was
+/// weighed and declined — not because they are hard, but because a VML shape's
+/// colour is one input to a fill this engine already renders, so the work is
+/// small and the payoff is real; it simply has not been asked for by any
+/// document in the corpus. Revisit when one turns up.
 pub(super) fn parse_color(s: &str) -> Option<VmlColor> {
     let hex = s.strip_prefix('#').unwrap_or(s);
     if hex.len() == 6 && hex.bytes().all(|b| b.is_ascii_hexdigit()) {

--- a/src/docx/parse/vml/path_commands.rs
+++ b/src/docx/parse/vml/path_commands.rs
@@ -60,7 +60,21 @@ pub(super) fn parse_path_commands(s: Option<String>) -> Vec<VmlPathCommand> {
                 tokens.push(&rest[..end]);
                 rest = &rest[end..];
             } else {
-                rest = &rest[1..]; // skip unrecognized char
+                // `rest[1..]` is a byte index, and it is on a character
+                // boundary only by a chain of reasoning rather than a guard:
+                // `end == 0` is reachable only when `rest` starts with one of
+                // the delimiters `find` matches, and every one of those (`,`,
+                // `@`, ASCII whitespace, ASCII alphabetic) is a single byte.
+                //
+                // **Add a non-ASCII delimiter above and this panics** on any
+                // path string containing it. Guard it with `is_char_boundary`
+                // or advance by the character's own length before extending
+                // the set. The same fixed-index hazard took down a *library*
+                // once — `is_toc_entry_name` panicked on style names like
+                // `Заголовок 1` whose byte 4 split a codepoint (fixed in #146);
+                // every other fixed-index slice in non-test code was swept
+                // then, and this is the one that survived on reasoning alone.
+                rest = &rest[1..];
             }
         }
     }
@@ -164,6 +178,12 @@ pub(super) fn parse_path_commands(s: Option<String>) -> Vec<VmlPathCommand> {
                         cmds.push(VmlPathCommand::LineTo { x, y });
                     }
                 } else {
+                    // `qb` (quadratic bezier) reaches this arm and is dropped
+                    // with a warning rather than modelled. Deliberate, and
+                    // inert: `VmlPathCommand` is not consumed by the renderer
+                    // at all — no VML custom path is drawn today — so a `QuadTo`
+                    // variant would be plumbing with no observable effect.
+                    // Model it when VML custom-path rendering lands, not before.
                     log::warn!("vml-path: unsupported command {:?}", tok);
                 }
             }

--- a/src/docx/parse/vml/style.rs
+++ b/src/docx/parse/vml/style.rs
@@ -176,7 +176,11 @@ pub(super) fn parse_length(s: &str) -> Option<VmlLength> {
         return None;
     }
 
-    // Try known unit suffixes.
+    // Try known unit suffixes. `pc` (picas) is the one CSS2 unit VML allows
+    // that is deliberately absent: it falls through to the warn-and-reject arm
+    // below rather than being converted at 1pc = 12pt. Nothing in the corpus
+    // uses it, and a silently-wrong length is worse than a warned-away one —
+    // add it with a test the day a document needs it.
     let (num_str, unit) = if let Some(n) = s.strip_suffix("pt") {
         (n, VmlLengthUnit::Pt)
     } else if let Some(n) = s.strip_suffix("in") {

--- a/src/model/dup.rs
+++ b/src/model/dup.rs
@@ -43,6 +43,48 @@
 //! Because the occurrences survive, a consumer that wants a different rule can
 //! have one without touching the parser: [`Dup::all`] hands back every
 //! occurrence in document order.
+//!
+//! # Where a `Dup` goes, and why that is not a matter of taste
+//!
+//! On a **property-bag field** — a direct child of `w:pPr`, `w:rPr`, `w:tblPr`,
+//! `w:trPr`, `w:tcPr`, `w:sectPr`. **Never inside a composite value type**
+//! ([`crate::model::ParagraphBorders`], `Border`, `EdgeInsets`, `Transform2D`),
+//! which stay plain and `Copy`.
+//!
+//! This was settled by two whole-tree attempts that collapsed before it was
+//! clear, and re-deriving it is expensive enough to be worth stating. Widening
+//! the *sides* inside `ParagraphBorders` strips `Copy` from a type layout reads
+//! in 59 places, turns one bordered paragraph into five heap allocations, and
+//! cascades through every reader: compile errors went 82 → 216 on one attempt
+//! and 143 → 180 on the other, and neither converged. Widening the *owner* cost
+//! 12 errors and was fixed in a single pass.
+//!
+//! The property-bag child is also the level §17.7.2 operates at, so `Dup` and
+//! the style cascade line up instead of crossing. The price is that a repeated
+//! `<w:top>` inside one `<w:pBdr>` still collapses at the seam — not maximally
+//! lossless, and deliberate.
+//!
+//! The `Option<bool>` toggles are excluded for the opposite reason and should
+//! stay that way: they come from `last_toggle`, where last-wins is §17.7.2's
+//! own rule rather than this parser's choice, and converting them would erase
+//! the distinction `crate::docx::parse::primitives::duplicates` exists to
+//! record.
+//!
+//! # What the corpus proves about this, and what it does not
+//!
+//! Measured — do not re-measure. **0 of 20** committed documents repeat a
+//! property-bag child, so "corpus renders byte-identical" proves no regression
+//! and *nothing at all* about the tolerance itself. Against eight synthetic
+//! documents built for it: **7 of 8** were fatal before this type existed
+//! (`tcMar` alone had been fixed separately), **8 of 8** convert now, and each
+//! renders identically to the same document carrying only the winning
+//! occurrence. That validates internal consistency — not that Word picks last,
+//! which still needs the reference render named in
+//! `crate::docx::parse::primitives::duplicates`.
+//!
+//! Cost is within noise on all four benchmark documents by whole-process
+//! timing. Treat that as **no measurable cost**, not as the speedup the
+//! criterion reports showed, which has no mechanism anyone could name.
 
 /// Every occurrence of a child element the schema allows at most once.
 ///

--- a/src/render/emoji/cluster.rs
+++ b/src/render/emoji/cluster.rs
@@ -86,6 +86,16 @@ pub enum FlagKind {
 ///
 /// Adjacent text clusters are merged into one [`InlineCluster::Text`] span.
 /// Empty input yields an empty vector.
+///
+/// # Keep single-codepoint clusters out of the emoji pipeline
+///
+/// A correctness rule, not an optimisation, and worth stating because it looks
+/// like one. A lone codepoint needs no GSUB — there is no sequence to shape —
+/// so routing it through the colour pipeline buys nothing. It also actively
+/// breaks: per UTS #51 a character like `U+2612` BALLOT BOX WITH X defaults to
+/// **text** presentation unless followed by VS-16, and Apple Color Emoji maps
+/// it to glyph 0. Sent to the colour pipeline it draws nothing; left as text it
+/// draws from the document's own face, which is what the spec asks for.
 pub fn classify(text: &str) -> Vec<InlineCluster<'_>> {
     let mut out = Vec::new();
     let mut text_start: Option<usize> = None;

--- a/src/render/layout/table/measure.rs
+++ b/src/render/layout/table/measure.rs
@@ -35,6 +35,17 @@ pub(super) fn measure_table_rows(
     // §17.4.44: the slots were shrunk by one `cell_spacing` before they got
     // here, so adding it back recovers the table's own outer width — the
     // spacing is carved out of the table, not added to it.
+    //
+    // **Word reference render needed** (issue #165): whether the gap at the table's *own
+    // edges* is one full spacing or a half. §17.4.44 says the spacing sits
+    // "between adjacent cells and the edges of the table" without saying
+    // whether an edge gets the same amount as the gap between two cells — one
+    // full spacing everywhere is what is implemented, matching HTML's
+    // `cellspacing`, and the spec licenses but does not require it. What would
+    // settle it: a table with a large `w:tblCellSpacing` and a visible outer
+    // border, so the edge gap can be measured against the inter-cell gap.
+    // Nothing in the corpus sets a non-zero value, so no test distinguishes
+    // the two readings either.
     let table_width: Pt = col_widths.iter().copied().sum::<Pt>() + cell_spacing;
     let num_rows = rows.len();
     let mut row_heights = Vec::with_capacity(num_rows);


### PR DESCRIPTION
The file was gitignored, so nothing in it reached a fresh clone and one `rm -rf plans/` would have taken it. Everything durable in it now lives where it applies; the file is gone.

To the code, at the site that makes the choice:

- model/dup.rs — where a `Dup` goes and why it is not a matter of taste. Two whole-tree attempts collapsed before this was clear (errors went 82 -> 216 and 143 -> 180, neither converging; widening the owner cost 12 and was fixed in one pass), which is expensive enough to re-derive that it belongs next to the type. Also what the corpus does and does not prove about duplicate tolerance: 0 of 20 documents exercise it.
- table/measure.rs — the §17.4.44 ambiguity about spacing at the table's own edges. This one existed *only* in the gitignored file: the code stated the choice but never that it was a choice.
- vml/path_commands.rs — why `rest[1..]` is on a character boundary by reasoning rather than by a guard, and what breaks if the delimiter set gains a non-ASCII member.
- vml/color.rs, vml/style.rs, vml/path_commands.rs — the VML forms that are deliberately not modelled (3-digit hex, two-token colour commands, `pc`, `qb`) and why each is inert today.
- emoji/cluster.rs — why single-codepoint clusters stay out of the colour pipeline. It reads like an optimisation and is a correctness rule.

To AGENTS.md, where there is no site because no code was written: the rejected optimisations and the measurements that closed them, the investigated-and-rejected list, the §20.1.10.85 citation conflict, the `textlayout` binary-size cost, and the three build conventions CI cannot enforce (spec-first tests, a mutation check, explained pixel diffs).

To the tracker: issue #165 batches the three questions that need a Word reference render, since those are actionable work rather than decisions.

Also corrects the OOXML Reference section, which still told agents to consult and update a `docs/` directory that was deliberately deleted page by page, and now states the rule this commit exists to satisfy — anything in /plans/ that must outlive the work has to be moved out before the file is deleted.