### PR TITLE
docs: record what the cell-spacing render answered, and what it did not (#165)

### DIFF
--- a/src/render/layout/table/measure.rs
+++ b/src/render/layout/table/measure.rs
@@ -36,16 +36,23 @@ pub(super) fn measure_table_rows(
     // here, so adding it back recovers the table's own outer width — the
     // spacing is carved out of the table, not added to it.
     //
-    // **Word reference render needed** (issue #165): whether the gap at the table's *own
-    // edges* is one full spacing or a half. §17.4.44 says the spacing sits
-    // "between adjacent cells and the edges of the table" without saying
-    // whether an edge gets the same amount as the gap between two cells — one
-    // full spacing everywhere is what is implemented, matching HTML's
-    // `cellspacing`, and the spec licenses but does not require it. What would
-    // settle it: a table with a large `w:tblCellSpacing` and a visible outer
-    // border, so the edge gap can be measured against the inter-cell gap.
-    // Nothing in the corpus sets a non-zero value, so no test distinguishes
-    // the two readings either.
+    // §17.4.44 says the spacing sits "between adjacent cells and the edges of
+    // the table" without saying whether an edge gets the same amount as the gap
+    // between two cells. **Settled** (issue #165) by a Word render of
+    // `test-files/issue-165-cellspacing.docx`: the two are equal — one full
+    // spacing everywhere, which is what is implemented here and what HTML's
+    // `cellspacing` does. The half-gap reading is out.
+    //
+    // What that render did *not* confirm is the magnitude. Word's gaps came out
+    // visibly wider than this engine's for the probe's `w:tblCellSpacing
+    // w:w="400"` (= 20pt), which no reading of "one full spacing everywhere"
+    // explains. Tracked separately; the equality above holds either way, since
+    // it is a ratio.
+    //
+    // Note this is *carved out of* the table rather than added to it, which is
+    // a separate claim from either — and the one to suspect first if the
+    // magnitude turns out to be a table-width accounting error rather than a
+    // per-gap one.
     let table_width: Pt = col_widths.iter().copied().sum::<Pt>() + cell_spacing;
     let num_rows = rows.len();
     let mut row_heights = Vec::with_capacity(num_rows);


### PR DESCRIPTION
The Word render of `test-files/issue-165-cellspacing.docx` settled §17.4.44's edge-versus-inter-cell question: the two gaps are equal, which is what this engine already does. The half-gap reading is out, so the comment saying the question is open is now wrong.

It also surfaced something the probe was not built to ask: Word's gaps are visibly wider than ours for the probe's `w:w="400"` (20pt), which "one full spacing everywhere" does not explain at any reading. Recorded at the site with the one lead worth following first — the spacing is carved out of the table's width rather than added to it, so a table-width accounting error would look exactly like a per-gap one.

Comment only; no behaviour change, and the corpus is untouched.