### PR TITLE
Add hyperlink support for math fragments

### DIFF
--- a/src/render/layout/fragment/collect.rs
+++ b/src/render/layout/fragment/collect.rs
@@ -982,7 +982,13 @@ where
                 // §22.1: one m:oMath — runs, superscripts and fraction
                 // stacks in the math face.
                 Inline::Math(math) => {
-                    super::math::emit_math_fragments(math, ctx, measure_text, &mut fragments);
+                    super::math::emit_math_fragments(
+                        math,
+                        ctx,
+                        hyperlink_url,
+                        measure_text,
+                        &mut fragments,
+                    );
                 }
                 Inline::AlternateContent(ac) => {
                     use crate::render::layout::{live_mc_branch, McBranch};
@@ -1423,6 +1429,29 @@ mod tests {
             width, 12.0,
             "only the visible half of the link, got {frags:?}"
         );
+    }
+
+    /// An `m:oMath` shares `ParaChildXml`'s content model with an ordinary
+    /// run, so it can legally sit inside a `w:hyperlink` — every glyph the
+    /// equation draws must get the same annotation an ordinary run in the
+    /// same hyperlink would.
+    #[test]
+    fn a_math_equation_inside_a_hyperlink_carries_its_target() {
+        let inlines = vec![Inline::Hyperlink(crate::model::Hyperlink {
+            target: crate::model::HyperlinkTarget::ExternalUrl("https://example.com".into()),
+            content: vec![Inline::Math(MathBlock {
+                content: vec![MathElement::Run(MathRun { text: "x".into() })],
+            })],
+        })];
+        let frags = collect(&inlines, &default_ctx(12.0));
+        assert_eq!(frags.len(), 1);
+        match &frags[0] {
+            Fragment::Text { hyperlink_url, .. } => assert_eq!(
+                hyperlink_url.as_ref(),
+                Some(&LinkTarget::External(Rc::from("https://example.com"))),
+            ),
+            other => panic!("expected text, got {other:?}"),
+        }
     }
 
     /// **Known limit, characterized rather than fixed.** Word hides a `w:sym`,

--- a/src/render/layout/fragment/fallback.rs
+++ b/src/render/layout/fragment/fallback.rs
@@ -511,6 +511,7 @@ where
         break_after,
         width,
         metrics,
+        hyperlink_url,
     } = fragment
     else {
         unreachable!("guarded by the caller's `matches!` check")
@@ -525,6 +526,7 @@ where
             metrics,
             baseline_offset,
             break_after,
+            hyperlink_url,
         };
     }
 
@@ -549,6 +551,7 @@ where
         metrics,
         baseline_offset,
         break_after,
+        hyperlink_url,
     }
 }
 
@@ -879,6 +882,7 @@ mod tests {
             metrics,
             baseline_offset: Pt::ZERO,
             break_after: BreakAfter::Opportunity,
+            hyperlink_url: None,
         }
     }
 

--- a/src/render/layout/fragment/math.rs
+++ b/src/render/layout/fragment/math.rs
@@ -10,22 +10,36 @@ use crate::render::fonts::Toggle;
 
 use super::text::{emit_text_words, TextRunStyle};
 use super::{
-    BreakAfter, FontProps, Fragment, FragmentCtx, MathRow, TextMetrics, FRACTION_GAP_RATIO,
-    FRACTION_RULE_RATIO, FRACTION_SIDE_PAD_RATIO, MATH_AXIS_RATIO, SUPERSCRIPT_ASCENT_OFFSET_RATIO,
-    SUPERSCRIPT_FONT_SIZE_RATIO,
+    BreakAfter, FontProps, Fragment, FragmentCtx, LinkTarget, MathRow, TextMetrics,
+    FRACTION_GAP_RATIO, FRACTION_RULE_RATIO, FRACTION_SIDE_PAD_RATIO, MATH_AXIS_RATIO,
+    SUPERSCRIPT_ASCENT_OFFSET_RATIO, SUPERSCRIPT_FONT_SIZE_RATIO,
 };
 
 /// Emit one `m:oMath` into the paragraph's fragment stream.
+///
+/// `hyperlink_url` is the target of the enclosing `w:hyperlink`, if any — an
+/// `m:oMath` shares `ParaChildXml`'s content model with ordinary runs, so it
+/// can legally sit inside one, and every glyph the equation draws gets the
+/// same annotation an ordinary run in the same hyperlink would.
 pub(super) fn emit_math_fragments<F>(
     math: &MathBlock,
     ctx: &FragmentCtx<'_>,
+    hyperlink_url: Option<&LinkTarget>,
     measure_text: &F,
     fragments: &mut Vec<Fragment>,
 ) where
     F: Fn(&str, &FontProps) -> (Pt, TextMetrics),
 {
     let font = math_font(ctx.default_size);
-    emit_elements(&math.content, &font, Pt::ZERO, ctx, measure_text, fragments);
+    emit_elements(
+        &math.content,
+        &font,
+        Pt::ZERO,
+        ctx,
+        hyperlink_url,
+        measure_text,
+        fragments,
+    );
 }
 
 /// The math face at a given size. Word renders math in Cambria Math; the
@@ -52,6 +66,7 @@ fn emit_elements<F>(
     font: &FontProps,
     baseline_offset: Pt,
     ctx: &FragmentCtx<'_>,
+    hyperlink_url: Option<&LinkTarget>,
     measure_text: &F,
     fragments: &mut Vec<Fragment>,
 ) where
@@ -67,10 +82,25 @@ fn emit_elements<F>(
                     border: None,
                     baseline_offset,
                 };
-                emit_text_words(&mapped, font, &style, None, measure_text, fragments);
+                emit_text_words(
+                    &mapped,
+                    font,
+                    &style,
+                    hyperlink_url,
+                    measure_text,
+                    fragments,
+                );
             }
             MathElement::Superscript { base, sup } => {
-                emit_elements(base, font, baseline_offset, ctx, measure_text, fragments);
+                emit_elements(
+                    base,
+                    font,
+                    baseline_offset,
+                    ctx,
+                    hyperlink_url,
+                    measure_text,
+                    fragments,
+                );
                 // The exponent belongs to its base: no line break between.
                 if let Some(Fragment::Text { break_after, .. }) = fragments.last_mut() {
                     *break_after = BreakAfter::Prohibited;
@@ -80,7 +110,15 @@ fn emit_elements<F>(
                 sup_font.size = font.size * SUPERSCRIPT_FONT_SIZE_RATIO;
                 let sup_offset =
                     baseline_offset - base_metrics.ascent * SUPERSCRIPT_ASCENT_OFFSET_RATIO;
-                emit_elements(sup, &sup_font, sup_offset, ctx, measure_text, fragments);
+                emit_elements(
+                    sup,
+                    &sup_font,
+                    sup_offset,
+                    ctx,
+                    hyperlink_url,
+                    measure_text,
+                    fragments,
+                );
             }
             MathElement::Fraction { num, den } => {
                 fragments.push(fraction_fragment(
@@ -89,6 +127,7 @@ fn emit_elements<F>(
                     font,
                     baseline_offset,
                     ctx,
+                    hyperlink_url,
                     measure_text,
                 ));
             }
@@ -107,6 +146,7 @@ fn fraction_fragment<F>(
     font: &FontProps,
     baseline_offset: Pt,
     ctx: &FragmentCtx<'_>,
+    hyperlink_url: Option<&LinkTarget>,
     measure_text: &F,
 ) -> Fragment
 where
@@ -134,6 +174,7 @@ where
         metrics,
         baseline_offset,
         break_after: BreakAfter::Opportunity,
+        hyperlink_url: hyperlink_url.cloned(),
     }
 }
 
@@ -253,7 +294,7 @@ mod tests {
             }],
         };
         let mut fragments = Vec::new();
-        emit_math_fragments(&math, &ctx(), &dummy_measure, &mut fragments);
+        emit_math_fragments(&math, &ctx(), None, &dummy_measure, &mut fragments);
 
         assert_eq!(fragments.len(), 2, "base + exponent");
         match (&fragments[0], &fragments[1]) {
@@ -293,7 +334,7 @@ mod tests {
             }],
         };
         let mut fragments = Vec::new();
-        emit_math_fragments(&math, &ctx(), &dummy_measure, &mut fragments);
+        emit_math_fragments(&math, &ctx(), None, &dummy_measure, &mut fragments);
 
         assert_eq!(fragments.len(), 1);
         match &fragments[0] {
@@ -327,5 +368,103 @@ mod tests {
         assert_eq!(map_math_italic("x2"), "\u{1D465}2");
         assert_eq!(map_math_italic("h"), "\u{210E}");
         assert_eq!(map_math_italic("A + 1"), "\u{1D434} + 1");
+    }
+
+    /// An `m:oMath` sharing `ParaChildXml`'s content model with ordinary runs
+    /// means it can sit inside a `w:hyperlink` — every glyph the run
+    /// produces must carry the same annotation an ordinary run in the same
+    /// hyperlink would.
+    #[test]
+    fn a_math_run_inside_a_hyperlink_carries_its_target() {
+        let target = LinkTarget::External(Rc::from("https://example.invalid"));
+        let math = MathBlock {
+            content: vec![run("x")],
+        };
+        let mut fragments = Vec::new();
+        emit_math_fragments(&math, &ctx(), Some(&target), &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), 1);
+        match &fragments[0] {
+            Fragment::Text { hyperlink_url, .. } => {
+                assert_eq!(hyperlink_url.as_ref(), Some(&target));
+            }
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    /// A superscript's base and exponent are two separate `Fragment::Text`s
+    /// (see `superscript_raises_and_shrinks_the_exponent`) — both must carry
+    /// the hyperlink, not just the base.
+    #[test]
+    fn a_math_superscript_inside_a_hyperlink_carries_its_target_on_both_parts() {
+        let target = LinkTarget::External(Rc::from("https://example.invalid"));
+        let math = MathBlock {
+            content: vec![MathElement::Superscript {
+                base: vec![run("x")],
+                sup: vec![run("2")],
+            }],
+        };
+        let mut fragments = Vec::new();
+        emit_math_fragments(&math, &ctx(), Some(&target), &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), 2);
+        for fragment in &fragments {
+            match fragment {
+                Fragment::Text { hyperlink_url, .. } => {
+                    assert_eq!(hyperlink_url.as_ref(), Some(&target));
+                }
+                other => panic!("expected text, got {other:?}"),
+            }
+        }
+    }
+
+    /// A fraction is one pre-measured atom (`Fragment::MathFraction`, not
+    /// `Fragment::Text`) — it needs its own `hyperlink_url` field, carried
+    /// the same way.
+    #[test]
+    fn a_math_fraction_inside_a_hyperlink_carries_its_target() {
+        let target = LinkTarget::External(Rc::from("https://example.invalid"));
+        let math = MathBlock {
+            content: vec![MathElement::Fraction {
+                num: vec![run("1")],
+                den: vec![run("2")],
+            }],
+        };
+        let mut fragments = Vec::new();
+        emit_math_fragments(&math, &ctx(), Some(&target), &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), 1);
+        match &fragments[0] {
+            Fragment::MathFraction { hyperlink_url, .. } => {
+                assert_eq!(hyperlink_url.as_ref(), Some(&target));
+            }
+            other => panic!("expected a fraction, got {other:?}"),
+        }
+    }
+
+    /// The stated behaviour when there is no hyperlink: unchanged from before
+    /// this field existed.
+    #[test]
+    fn math_without_a_hyperlink_carries_no_target() {
+        let math = MathBlock {
+            content: vec![
+                run("x"),
+                MathElement::Fraction {
+                    num: vec![run("1")],
+                    den: vec![run("2")],
+                },
+            ],
+        };
+        let mut fragments = Vec::new();
+        emit_math_fragments(&math, &ctx(), None, &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), 2);
+        for fragment in &fragments {
+            match fragment {
+                Fragment::Text { hyperlink_url, .. } => assert_eq!(*hyperlink_url, None),
+                Fragment::MathFraction { hyperlink_url, .. } => assert_eq!(*hyperlink_url, None),
+                other => panic!("expected text or a fraction, got {other:?}"),
+            }
+        }
     }
 }

--- a/src/render/layout/fragment/mod.rs
+++ b/src/render/layout/fragment/mod.rs
@@ -296,6 +296,11 @@ pub enum Fragment {
         metrics: TextMetrics,
         baseline_offset: Pt,
         break_after: BreakAfter,
+        /// Hyperlink target, if this `m:oMath` sits inside a `w:hyperlink` —
+        /// see `Fragment::Text`'s field of the same name. One annotation
+        /// covers the whole fraction rather than per-row, matching how a
+        /// fraction is one atom everywhere else in this pipeline.
+        hyperlink_url: Option<LinkTarget>,
     },
     /// One emoji grapheme cluster (UAX #29) classified as an emoji sequence
     /// (UTS #51), to be rasterized at paint time via Skia's raster backend

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -783,6 +783,7 @@ pub(super) fn emit_line_commands(
                     metrics: _,
                     baseline_offset,
                     break_after: _,
+                    hyperlink_url,
                 } => {
                     use crate::render::layout::fragment::{
                         FRACTION_GAP_RATIO, FRACTION_RULE_RATIO, FRACTION_SIDE_PAD_RATIO,
@@ -819,6 +820,32 @@ pub(super) fn emit_line_commands(
                         color: *color,
                         width: rule,
                     });
+
+                    // One annotation over the whole fraction — it is one atom
+                    // everywhere else in this pipeline, not one per row. See
+                    // the `Fragment::Text` arm above for the routing rationale.
+                    if let Some(link) = hyperlink_url {
+                        let rect = crate::render::geometry::PtRect::from_xywh(
+                            x,
+                            *cursor_y,
+                            *width,
+                            line_height,
+                        );
+                        match link {
+                            LinkTarget::External(url) => {
+                                commands.push(DrawCommand::LinkAnnotation {
+                                    rect,
+                                    url: url.clone(),
+                                })
+                            }
+                            LinkTarget::Internal(dest) => {
+                                commands.push(DrawCommand::InternalLink {
+                                    rect,
+                                    destination: dest.clone(),
+                                })
+                            }
+                        }
+                    }
 
                     x += *width
                         + distribution_extra

--- a/src/render/layout/paragraph/mod.rs
+++ b/src/render/layout/paragraph/mod.rs
@@ -537,7 +537,9 @@ mod tests {
     use super::*;
     use crate::model::{Alignment, PTabAlignment, PTabRelativeTo};
     use crate::render::fonts::Toggle;
-    use crate::render::layout::fragment::{FontProps, LinkTarget, TextMetrics};
+    use crate::render::layout::fragment::{
+        BreakAfter, FontProps, LinkTarget, MathRow, TextMetrics,
+    };
     use crate::render::resolve::color::RgbColor;
     use std::rc::Rc;
 
@@ -582,6 +584,44 @@ mod tests {
             *hyperlink_url = Some(LinkTarget::External(std::rc::Rc::from(url)));
         }
         fragment
+    }
+
+    /// A minimal `§22.1` fraction fragment, for testing the paint side of
+    /// a hyperlinked equation independently of the OMML→fragment path.
+    fn math_fraction_frag(hyperlink_url: Option<LinkTarget>) -> Fragment {
+        let font = Rc::new(FontProps {
+            rtl: crate::render::fonts::Toggle::Absent,
+            family: Rc::from("Cambria Math"),
+            size: Pt::new(12.0),
+            bold: Toggle::Absent,
+            italic: Toggle::Absent,
+            underline: false,
+            char_spacing: Pt::ZERO,
+            text_scale: 1.0,
+            underline_position: Pt::ZERO,
+            underline_thickness: Pt::ZERO,
+        });
+        let metrics = TextMetrics {
+            ascent: Pt::new(10.0),
+            descent: Pt::new(4.0),
+            leading: Pt::ZERO,
+        };
+        let row = |text: &str, width: f32| MathRow {
+            text: Rc::from(text),
+            font: font.clone(),
+            width: Pt::new(width),
+            metrics,
+        };
+        Fragment::MathFraction {
+            num: row("1", 6.0),
+            den: row("2", 6.0),
+            color: RgbColor::BLACK,
+            width: Pt::new(10.0),
+            metrics,
+            baseline_offset: Pt::ZERO,
+            break_after: BreakAfter::Opportunity,
+            hyperlink_url,
+        }
     }
 
     fn underlined_text_frag(text: &str, width: f32) -> Fragment {
@@ -916,6 +956,49 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, DrawCommand::LinkAnnotation { .. })),
             "internal link must not be emitted as an external URI"
+        );
+    }
+
+    /// A `§22.1` fraction inside a `w:hyperlink` gets one annotation over its
+    /// whole box, the same way an ordinary run in the same hyperlink would —
+    /// see `non_http_external_link_emits_uri_annotation` for the run case.
+    #[test]
+    fn hyperlinked_math_fraction_emits_a_link_annotation() {
+        let frag = math_fraction_frag(Some(LinkTarget::External("https://example.invalid".into())));
+        let result = layout_paragraph(
+            &[frag],
+            &body_constraints(200.0),
+            &ParagraphStyle::default(),
+            Pt::new(14.0),
+            None,
+        );
+        assert!(
+            result.commands.iter().any(|c| matches!(
+                c,
+                DrawCommand::LinkAnnotation { url, .. } if &**url == "https://example.invalid"
+            )),
+            "fraction hyperlink annotation, got {:?}",
+            result.commands
+        );
+    }
+
+    /// The stated behaviour when there is no hyperlink: unchanged.
+    #[test]
+    fn a_math_fraction_without_a_hyperlink_emits_no_annotation() {
+        let frag = math_fraction_frag(None);
+        let result = layout_paragraph(
+            &[frag],
+            &body_constraints(200.0),
+            &ParagraphStyle::default(),
+            Pt::new(14.0),
+            None,
+        );
+        assert!(
+            !result
+                .commands
+                .iter()
+                .any(|c| matches!(c, DrawCommand::LinkAnnotation { .. })),
+            "no hyperlink on the fragment, no annotation"
         );
     }
 


### PR DESCRIPTION
Introduce hyperlink support for math fragments, allowing them to be annotated correctly when placed inside hyperlinks. This change ensures that the entire fraction is treated as a single entity for hyperlinking, consistent with other text fragments. Tests validate the expected behavior for both hyperlinked and non-hyperlinked cases.