### PR TITLE
Refactor fraction geometry calculations for consistency

### DIFF
--- a/src/render/layout/fragment/fallback.rs
+++ b/src/render/layout/fragment/fallback.rs
@@ -536,7 +536,7 @@ where
     // widened, possibly re-fonted) rows — the same formula `fraction_fragment`
     // used to build them the first time, so the space this fraction now
     // occupies is honest about what it contains.
-    let (width, metrics) = super::math::fraction_geometry(
+    let geometry = super::math::fraction_geometry(
         num.font.size,
         num.width,
         num.metrics,
@@ -547,8 +547,8 @@ where
         num,
         den,
         color,
-        width,
-        metrics,
+        width: geometry.width,
+        metrics: geometry.metrics,
         baseline_offset,
         break_after,
         hyperlink_url,
@@ -867,7 +867,7 @@ mod tests {
     ) -> Fragment {
         let num = math_row(num_text, num_family);
         let den = math_row(den_text, den_family);
-        let (width, metrics) = super::super::math::fraction_geometry(
+        let geometry = super::super::math::fraction_geometry(
             Pt::new(12.0),
             num.width,
             num.metrics,
@@ -878,8 +878,8 @@ mod tests {
             num,
             den,
             color: RgbColor::BLACK,
-            width,
-            metrics,
+            width: geometry.width,
+            metrics: geometry.metrics,
             baseline_offset: Pt::ZERO,
             break_after: BreakAfter::Opportunity,
             hyperlink_url: None,
@@ -967,16 +967,16 @@ mod tests {
                 metrics,
                 ..
             } => {
-                let (expected_width, expected_metrics) = super::super::math::fraction_geometry(
+                let expected = super::super::math::fraction_geometry(
                     num.font.size,
                     num.width,
                     num.metrics,
                     den.width,
                     den.metrics,
                 );
-                assert_eq!(width.raw(), expected_width.raw());
-                assert_eq!(metrics.ascent.raw(), expected_metrics.ascent.raw());
-                assert_eq!(metrics.descent.raw(), expected_metrics.descent.raw());
+                assert_eq!(width.raw(), expected.width.raw());
+                assert_eq!(metrics.ascent.raw(), expected.metrics.ascent.raw());
+                assert_eq!(metrics.descent.raw(), expected.metrics.descent.raw());
             }
             other => panic!("expected a fraction, got {other:?}"),
         }

--- a/src/render/layout/fragment/math.rs
+++ b/src/render/layout/fragment/math.rs
@@ -157,8 +157,7 @@ where
     let (num_width, num_metrics) = measure_text(&num_text, font);
     let (den_width, den_metrics) = measure_text(&den_text, font);
 
-    let (width, metrics) =
-        fraction_geometry(font.size, num_width, num_metrics, den_width, den_metrics);
+    let geometry = fraction_geometry(font.size, num_width, num_metrics, den_width, den_metrics);
 
     let row = |text: String, row_width: Pt, row_metrics: TextMetrics| MathRow {
         text: Rc::from(text.as_str()),
@@ -170,28 +169,51 @@ where
         num: row(num_text, num_width, num_metrics),
         den: row(den_text, den_width, den_metrics),
         color: ctx.default_color,
-        width,
-        metrics,
+        width: geometry.width,
+        metrics: geometry.metrics,
         baseline_offset,
         break_after: BreakAfter::Opportunity,
         hyperlink_url: hyperlink_url.cloned(),
     }
 }
 
-/// The fraction's overall width/metrics from its two rows' own.
+/// Every quantity derived from the `MATH_*`/`FRACTION_*` ratios that either
+/// the initial layout pass or the paint pass needs to place a fraction
+/// stack — the layout pass only wants `width`/`metrics`, the paint pass only
+/// wants `rule`/`gap`/`pad`/`axis`, but both must read them off the same
+/// call so the space line-fitting reserves and what paint actually draws
+/// cannot independently drift (see [`fraction_geometry`]).
+pub(crate) struct FractionGeometry {
+    /// max(row widths) plus side padding — the fragment's line-fitting width.
+    pub width: Pt,
+    /// Synthesized ascent/descent covering both rows plus the rule and gaps.
+    pub metrics: TextMetrics,
+    /// Thickness of the fraction rule.
+    pub rule: Pt,
+    /// Vertical clearance between the rule and each row.
+    pub gap: Pt,
+    /// Horizontal padding on each side of the wider row.
+    pub pad: Pt,
+    /// Distance from the row's baseline up to the math axis the rule is
+    /// centered on — paint derives the rule's y as `baseline - axis`.
+    pub axis: Pt,
+}
+
+/// The fraction's geometry from its two rows' own width/metrics.
 ///
-/// Shared between initial construction and
-/// [`super::fallback::apply_font_fallback`]'s repair of a row whose face got
-/// substituted: both must derive the stack's ascent/descent from the same
-/// `size`/`FRACTION_*` ratios, or the space line-fitting reserved for the
-/// fraction and what re-fallback leaves behind could disagree.
-pub(super) fn fraction_geometry(
+/// Shared between initial construction, [`super::fallback::apply_font_
+/// fallback`]'s repair of a row whose face got substituted, and the paint
+/// arm in `paragraph::line_emit` — all three must derive the stack's
+/// geometry from the same `size`/`FRACTION_*` ratios, or the space
+/// line-fitting reserves, what fallback repair leaves behind, and what paint
+/// actually draws could disagree with each other.
+pub(crate) fn fraction_geometry(
     size: Pt,
     num_width: Pt,
     num_metrics: TextMetrics,
     den_width: Pt,
     den_metrics: TextMetrics,
-) -> (Pt, TextMetrics) {
+) -> FractionGeometry {
     let axis = size * MATH_AXIS_RATIO;
     let rule = size * FRACTION_RULE_RATIO;
     let gap = size * FRACTION_GAP_RATIO;
@@ -203,7 +225,14 @@ pub(super) fn fraction_geometry(
         descent: (rule * 0.5 + gap + den_metrics.height() - axis).max(Pt::ZERO),
         leading: Pt::ZERO,
     };
-    (width, metrics)
+    FractionGeometry {
+        width,
+        metrics,
+        rule,
+        gap,
+        pad,
+        axis,
+    }
 }
 
 /// Flatten a fraction argument to plain text. The minimal scope renders

--- a/src/render/layout/fragment/mod.rs
+++ b/src/render/layout/fragment/mod.rs
@@ -30,6 +30,7 @@ pub use collect::{
     collect_fragments, FieldContext, FootnoteTracker, FragmentCtx, RecordedFootnote,
 };
 pub use fallback::{apply_font_fallback, FallbackLookup, RegistryFallback};
+pub(crate) use math::fraction_geometry;
 pub use shape::shape_complex_scripts;
 pub use split::split_oversized_fragments;
 
@@ -53,13 +54,18 @@ pub(super) const SUBSCRIPT_HEIGHT_OFFSET_RATIO: f32 = 0.08;
 // a Word reference render of `1/2 + 1/3 = 5/6` is what would refine them.
 
 /// Center of the fraction rule above the baseline.
-pub(crate) const MATH_AXIS_RATIO: f32 = 0.25;
+///
+/// Private rather than `pub(crate)`: [`fraction_geometry`] is now the only
+/// place that reads these four ratios (the paint arm in `paragraph::
+/// line_emit` used to rederive them independently and no longer does), so
+/// nothing outside this module has a reason to see them.
+const MATH_AXIS_RATIO: f32 = 0.25;
 /// Thickness of the fraction rule.
-pub(crate) const FRACTION_RULE_RATIO: f32 = 0.05;
+const FRACTION_RULE_RATIO: f32 = 0.05;
 /// Vertical clearance between the rule and each row.
-pub(crate) const FRACTION_GAP_RATIO: f32 = 0.08;
+const FRACTION_GAP_RATIO: f32 = 0.08;
 /// Horizontal padding on each side of the wider row.
-pub(crate) const FRACTION_SIDE_PAD_RATIO: f32 = 0.12;
+const FRACTION_SIDE_PAD_RATIO: f32 = 0.12;
 
 /// §17.11.12: baseline shift for a footnote/endnote reference mark, and for
 /// the matching number prefixed to the note body — as a fraction of the base

--- a/src/render/layout/paragraph/line_emit.rs
+++ b/src/render/layout/paragraph/line_emit.rs
@@ -785,16 +785,25 @@ pub(super) fn emit_line_commands(
                     break_after: _,
                     hyperlink_url,
                 } => {
-                    use crate::render::layout::fragment::{
-                        FRACTION_GAP_RATIO, FRACTION_RULE_RATIO, FRACTION_SIDE_PAD_RATIO,
-                        MATH_AXIS_RATIO,
-                    };
+                    use crate::render::layout::fragment::fraction_geometry;
+                    // Re-derive rule/gap/pad/axis from the same rows rather
+                    // than trusting the fragment's own `width`/`metrics`
+                    // (ignored above): one call site for the geometry means
+                    // paint and layout cannot independently drift the way two
+                    // hand-written copies of the `MATH_*`/`FRACTION_*` ratio
+                    // math already had.
+                    let geometry = fraction_geometry(
+                        num.font.size,
+                        num.width,
+                        num.metrics,
+                        den.width,
+                        den.metrics,
+                    );
                     let baseline = *cursor_y + line.ascent + *baseline_offset;
-                    let size = num.font.size;
-                    let rule = size * FRACTION_RULE_RATIO;
-                    let gap = size * FRACTION_GAP_RATIO;
-                    let pad = size * FRACTION_SIDE_PAD_RATIO;
-                    let bar_y = baseline - size * MATH_AXIS_RATIO;
+                    let rule = geometry.rule;
+                    let gap = geometry.gap;
+                    let pad = geometry.pad;
+                    let bar_y = baseline - geometry.axis;
 
                     let num_baseline = bar_y - rule * 0.5 - gap - num.metrics.descent;
                     let den_baseline = bar_y + rule * 0.5 + gap + den.metrics.ascent;


### PR DESCRIPTION
Unify fraction geometry calculations across modules to ensure consistent handling of width and metrics. This change enhances maintainability and reduces the risk of discrepancies in layout and rendering.