### PR TITLE
Fix superscript handling with fraction bases

### DIFF
--- a/src/render/layout/fragment/math.rs
+++ b/src/render/layout/fragment/math.rs
@@ -92,6 +92,7 @@ fn emit_elements<F>(
                 );
             }
             MathElement::Superscript { base, sup } => {
+                let base_start = fragments.len();
                 emit_elements(
                     base,
                     font,
@@ -102,8 +103,27 @@ fn emit_elements<F>(
                     fragments,
                 );
                 // The exponent belongs to its base: no line break between.
-                if let Some(Fragment::Text { break_after, .. }) = fragments.last_mut() {
-                    *break_after = BreakAfter::Prohibited;
+                // Guarded on `fragments.len() > base_start` because `base`
+                // can legally emit nothing — §22.1 defaults `SSupXml::base`
+                // to `vec![]`, and a text-less `m:r` is dropped before this
+                // point — in which case there is no base fragment to glue
+                // and `fragments.last_mut()` would otherwise reach back into
+                // whatever unrelated fragment preceded this equation.
+                //
+                // Matches both `Fragment::Text` (an ordinary base) and
+                // `Fragment::MathFraction` (a fraction as a base, e.g.
+                // `(1/2)²`) — the only two variants `emit_elements` can leave
+                // behind here. `line.rs`'s line-fitter has to honor
+                // `MathFraction`'s own `break_after` for this to matter; see
+                // its `is_break_point` match.
+                if fragments.len() > base_start {
+                    match fragments.last_mut().expect("checked non-empty above") {
+                        Fragment::Text { break_after, .. }
+                        | Fragment::MathFraction { break_after, .. } => {
+                            *break_after = BreakAfter::Prohibited;
+                        }
+                        _ => {}
+                    }
                 }
                 let (_, base_metrics) = measure_text("X", font);
                 let mut sup_font = font.clone();
@@ -349,6 +369,84 @@ mod tests {
                 assert!(sup_off.raw() < base_off.raw(), "exponent raised");
             }
             other => panic!("expected two text fragments, got {other:?}"),
+        }
+    }
+
+    /// A fraction can be a superscript's base (`(1/2)²` — `m:sSup` whose
+    /// `m:e` is `m:f`) — the exponent must still glue to it. `line.rs`'s
+    /// `is_break_point` has to honor `Fragment::MathFraction`'s own
+    /// `break_after` for this to matter; that half is covered in
+    /// `render::layout::line`'s own tests.
+    #[test]
+    fn superscript_glues_to_a_fraction_base() {
+        let math = MathBlock {
+            content: vec![MathElement::Superscript {
+                base: vec![MathElement::Fraction {
+                    num: vec![run("1")],
+                    den: vec![run("2")],
+                }],
+                sup: vec![run("2")],
+            }],
+        };
+        let mut fragments = Vec::new();
+        emit_math_fragments(&math, &ctx(), None, &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), 2, "fraction base + exponent");
+        match &fragments[0] {
+            Fragment::MathFraction { break_after, .. } => {
+                assert_eq!(
+                    *break_after,
+                    BreakAfter::Prohibited,
+                    "fraction base glued to sup"
+                );
+            }
+            other => panic!("expected the fraction base, got {other:?}"),
+        }
+    }
+
+    /// §22.1 lets `SSupXml::base` be empty — dropped by `convert_children`
+    /// when its only content is a text-less `m:r`, and reachable directly
+    /// too. The glue must not then reach backward past the equation into
+    /// whatever fragment preceded it in the same paragraph.
+    #[test]
+    fn superscript_with_an_empty_base_does_not_corrupt_a_preceding_fragment() {
+        let math = MathBlock {
+            content: vec![MathElement::Superscript {
+                base: vec![],
+                sup: vec![run("2")],
+            }],
+        };
+        let mut fragments = Vec::new();
+        // Ordinary prose preceding the equation in the same paragraph, with
+        // an ordinary break opportunity after it.
+        let style = TextRunStyle {
+            color: crate::render::resolve::color::RgbColor::BLACK,
+            shading: None,
+            border: None,
+            baseline_offset: Pt::ZERO,
+        };
+        emit_text_words(
+            "word",
+            &math_font(Pt::new(12.0)),
+            &style,
+            None,
+            &dummy_measure,
+            &mut fragments,
+        );
+        let before = fragments.len();
+
+        emit_math_fragments(&math, &ctx(), None, &dummy_measure, &mut fragments);
+
+        assert_eq!(fragments.len(), before + 1, "just the bare exponent");
+        match &fragments[0] {
+            Fragment::Text { break_after, .. } => {
+                assert_eq!(
+                    *break_after,
+                    BreakAfter::Opportunity,
+                    "an empty superscript base must not glue backward into unrelated prose"
+                );
+            }
+            other => panic!("expected the preceding word untouched, got {other:?}"),
         }
     }
 

--- a/src/render/layout/line.rs
+++ b/src/render/layout/line.rs
@@ -276,7 +276,9 @@ pub fn fit_lines_with_first(
         // sniffing the fragment's last character, against a list that had
         // already drifted from the one used to cut the fragments.
         let is_break_point = match frag {
-            Fragment::Text { break_after, .. } => *break_after == BreakAfter::Opportunity,
+            Fragment::Text { break_after, .. } | Fragment::MathFraction { break_after, .. } => {
+                *break_after == BreakAfter::Opportunity
+            }
             _ => true, // tabs, images, line breaks are always break points
         };
         if is_break_point {
@@ -353,6 +355,48 @@ mod tests {
     /// boundary, or one UAX #14 refuses to break inside.
     fn glued_frag(text: &str, width: f32) -> Fragment {
         frag(text, width, BreakAfter::Prohibited)
+    }
+
+    /// A `Fragment::MathFraction` with a caller-chosen `break_after` — e.g.
+    /// `(1/2)²`, where the fraction is a superscript's base and must glue to
+    /// the exponent that follows it (`fragment::math`'s `emit_elements` sets
+    /// `Prohibited` on exactly this fragment for that case).
+    fn math_fraction_frag(width: f32, break_after: BreakAfter) -> Fragment {
+        let row = |text: &str| crate::render::layout::fragment::MathRow {
+            text: text.into(),
+            font: Rc::new(FontProps {
+                rtl: crate::render::fonts::Toggle::Absent,
+                family: Rc::from("Test"),
+                size: Pt::new(12.0),
+                bold: Toggle::Absent,
+                italic: Toggle::Absent,
+                underline: false,
+                char_spacing: Pt::ZERO,
+                text_scale: 1.0,
+                underline_position: Pt::ZERO,
+                underline_thickness: Pt::ZERO,
+            }),
+            width: Pt::new(width * 0.5),
+            metrics: TextMetrics {
+                ascent: Pt::new(10.0),
+                descent: Pt::new(4.0),
+                leading: Pt::ZERO,
+            },
+        };
+        Fragment::MathFraction {
+            num: row("1"),
+            den: row("2"),
+            color: RgbColor::BLACK,
+            width: Pt::new(width),
+            metrics: TextMetrics {
+                ascent: Pt::new(10.0),
+                descent: Pt::new(4.0),
+                leading: Pt::ZERO,
+            },
+            baseline_offset: Pt::ZERO,
+            break_after,
+            hyperlink_url: None,
+        }
     }
 
     fn frag(text: &str, width: f32, break_after: BreakAfter) -> Fragment {
@@ -499,6 +543,28 @@ mod tests {
             text_frag("prefix ", 45.0),
             glued_frag("ID‑", 20.0),
             glued_frag("001", 35.0),
+        ];
+        let lines = fit_lines(&frags, Pt::new(70.0));
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].end, 1);
+        assert_eq!(lines[1].start, 1);
+        assert_eq!(lines[1].end, 3);
+    }
+
+    /// `Fragment::MathFraction` carries its own `break_after` (a fraction
+    /// used as a superscript's base, `(1/2)²`, is glued to the exponent that
+    /// follows it) — the fitter must honor that field exactly like a
+    /// `Fragment::Text`'s, not fall into the wildcard arm that used to treat
+    /// every non-text fragment as an unconditional break point regardless of
+    /// what it carried. Same shape as the test above, with the middle
+    /// fragment swapped for a glued `MathFraction`.
+    #[test]
+    fn a_prohibited_math_fraction_is_not_a_break_point() {
+        let frags = vec![
+            text_frag("prefix ", 45.0),
+            math_fraction_frag(20.0, BreakAfter::Prohibited),
+            text_frag("sup", 35.0),
         ];
         let lines = fit_lines(&frags, Pt::new(70.0));
 


### PR DESCRIPTION
Ensure superscripts correctly attach to fraction bases and manage break points, preventing unintended line breaks in mathematical expressions. Add tests to verify behavior with both non-empty and empty bases.