### PR TITLE
Refactor EMU ratio handling and improve SideXml deserialization

### DIFF
--- a/src/docx/parse/primitives/integer_measure.rs
+++ b/src/docx/parse/primitives/integer_measure.rs
@@ -46,17 +46,18 @@ impl<'de> Deserialize<'de> for IntegerMeasure {
     }
 }
 
-/// EMU per one §22.9.2.15 unit. `pc` and `pi` are two spellings of the pica.
-fn universal_unit_emu(suffix: &str) -> Option<i64> {
-    Some(match suffix {
-        "mm" => 36_000,
-        "cm" => 360_000,
-        "in" => 914_400,
-        "pt" => 12_700,
-        "pc" | "pi" => 152_400,
-        _ => return None,
-    })
-}
+/// §22.9.2.15 unit spellings and their EMU-per-unit ratio. `pc` and `pi` are
+/// two spellings of the pica. One table drives both the suffix match below
+/// and the ratio lookup, so the unit set cannot drift out of sync with
+/// itself.
+const UNIVERSAL_UNITS: &[(&str, i64)] = &[
+    ("mm", 36_000),
+    ("cm", 360_000),
+    ("in", 914_400),
+    ("pt", 12_700),
+    ("pc", 152_400),
+    ("pi", 152_400),
+];
 
 fn parse_integer_measure(raw: &str) -> Result<IntegerMeasure, &'static str> {
     if let Ok(value) = raw.parse::<i64>() {
@@ -76,11 +77,10 @@ fn parse_integer_measure(raw: &str) -> Result<IntegerMeasure, &'static str> {
         });
     }
 
-    for suffix in ["mm", "cm", "in", "pt", "pc", "pi"] {
+    for &(suffix, emu_per_unit) in UNIVERSAL_UNITS {
         let Some(head) = raw.strip_suffix(suffix) else {
             continue;
         };
-        let emu_per_unit = universal_unit_emu(suffix).expect("every listed suffix has a scale");
         let (negative, value) = parse_decimal_scaled(head, emu_per_unit, false)?;
         return Ok(IntegerMeasure {
             value,

--- a/src/docx/parse/properties/schema/insets.rs
+++ b/src/docx/parse/properties/schema/insets.rs
@@ -125,6 +125,22 @@ mod tests {
         assert!(r.is_err(), "a negative length side is still rejected");
     }
 
+    /// A percent side is never "honoured" here — only `dxa` is meaningful
+    /// for cell padding — so unlike a length side, its sign must not be
+    /// fatal either: the value is discarded regardless, the same rule
+    /// `measure.rs` applies to a spelling its own `@type` contradicts.
+    #[test]
+    fn negative_percent_side_drops_without_failing() {
+        let x: EdgeInsetsTwipsXml =
+            quick_xml::de::from_str(r#"<m><top w="-5%" type="pct"/></m>"#).unwrap();
+        let insets = EdgeInsets::from(x);
+        assert_eq!(
+            insets.top.raw(),
+            0,
+            "a negative percent side is dropped, not fatal"
+        );
+    }
+
     use super::*;
 
     fn parse(xml: &str) -> EdgeInsets<Twips> {

--- a/src/docx/parse/properties/schema/insets.rs
+++ b/src/docx/parse/properties/schema/insets.rs
@@ -5,7 +5,7 @@
 //! meaningful for cell padding; other `@type` values are ignored here.
 
 use crate::model::Dup;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::docx::model::dimension::{Dimension, Twips};
 use crate::docx::model::geometry::{EdgeInsets, PartialEdgeInsets};
@@ -24,35 +24,50 @@ pub(crate) struct EdgeInsetsTwipsXml {
     right: Vec<SideXml>,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug)]
 struct SideXml {
-    #[serde(rename = "@w", default, deserialize_with = "deserialize_side_width")]
     w: Option<Dimension<Twips>>,
 }
 
-/// A side's `@w` is CT_TblWidth's ST_MeasurementOrPercent, but only a length
-/// is meaningful for padding (the module doc owns why). A percent spelling —
-/// legal for the type, meaningless here — drops the side with a warning
-/// instead of failing the document, mirroring `TableMeasureXml`'s policy for
-/// a spelling that contradicts its `@type`.
-fn deserialize_side_width<'de, D>(deserializer: D) -> Result<Option<Dimension<Twips>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let Some(measure) = Option::<IntegerMeasure>::deserialize(deserializer)? else {
-        return Ok(None);
-    };
-    if measure.kind() == MeasureKind::Percent {
-        log::warn!("[table] dropping a cell-margin width spelled as a percentage");
-        return Ok(None);
+/// The raw shadow of `<w:top w:w="N" w:type="dxa"/>` etc.: both attributes
+/// have to be read together (`SideXml`'s own `Deserialize` below), since
+/// which spelling of "percent, not a length" `@w` used depends on `@type`.
+#[derive(Deserialize)]
+struct SideAttrsXml {
+    #[serde(rename = "@w", default)]
+    w: Option<IntegerMeasure>,
+    #[serde(rename = "@type", default)]
+    ty: Option<String>,
+}
+
+/// A side's `@w`/`@type` are CT_TblWidth's, but only a `dxa`-typed length is
+/// meaningful for padding (the module doc owns why). A percent spelling is
+/// legal for the type but meaningless here, and §17.18.91 admits two ways to
+/// write one: a literal `%` suffix on `@w` (§22.9.2.9, `MeasureKind::Percent`)
+/// or the older Transitional `w:type="pct"` alongside a bare number — a bare
+/// `w="2500"` under `type="pct"` is not 2500 twips. `auto`/`nil` name no
+/// width at all and drop the same way. Every one of those drops the side
+/// with a warning instead of failing the document, mirroring
+/// `TableMeasureXml`'s policy for a spelling that contradicts its `@type`.
+impl<'de> Deserialize<'de> for SideXml {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = SideAttrsXml::deserialize(deserializer)?;
+        let Some(measure) = raw.w else {
+            return Ok(SideXml { w: None });
+        };
+        let type_is_dxa_or_absent = matches!(raw.ty.as_deref(), None | Some("dxa"));
+        if measure.kind() == MeasureKind::Percent || !type_is_dxa_or_absent {
+            log::warn!("[table] dropping a cell-margin width that isn't a dxa length");
+            return Ok(SideXml { w: None });
+        }
+        let dimension = dimension_from_measure(measure).map_err(serde::de::Error::custom)?;
+        if measure.is_negative() {
+            return Err(serde::de::Error::custom(
+                "negative value is not valid for this OOXML measurement",
+            ));
+        }
+        Ok(SideXml { w: Some(dimension) })
     }
-    let dimension = dimension_from_measure(measure).map_err(serde::de::Error::custom)?;
-    if measure.is_negative() {
-        return Err(serde::de::Error::custom(
-            "negative value is not valid for this OOXML measurement",
-        ));
-    }
-    Ok(Some(dimension))
 }
 
 /// Conversion used for the table-level default (`<w:tblCellMar>`). Per
@@ -138,6 +153,37 @@ mod tests {
             insets.top.raw(),
             0,
             "a negative percent side is dropped, not fatal"
+        );
+    }
+
+    /// §17.18.91 `ST_TblWidthType` has two ways to spell "percent, not a
+    /// length": a literal `%` suffix on `@w` (§22.9.2.9) or the older
+    /// Transitional `w:type="pct"` alongside a bare number. Both must drop
+    /// the side the same way — a bare `w="2500"` under `type="pct"` is not
+    /// 2500 twips of padding.
+    #[test]
+    fn side_widths_drop_the_type_pct_spelling_of_percent_too() {
+        let x: EdgeInsetsTwipsXml =
+            quick_xml::de::from_str(r#"<m><top w="2500" type="pct"/></m>"#).unwrap();
+        let insets = EdgeInsets::from(x);
+        assert_eq!(
+            insets.top.raw(),
+            0,
+            "type=\"pct\" with a bare number must drop, not read as 2500 twips"
+        );
+    }
+
+    /// `auto`/`nil` name no width at all — the same "only dxa is meaningful
+    /// here" rule that drops a percent spelling.
+    #[test]
+    fn side_widths_drop_auto_and_nil_types() {
+        let x: EdgeInsetsTwipsXml =
+            quick_xml::de::from_str(r#"<m><top w="100" type="auto"/></m>"#).unwrap();
+        let insets = EdgeInsets::from(x);
+        assert_eq!(
+            insets.top.raw(),
+            0,
+            "type=\"auto\" must drop, not read as twips"
         );
     }
 

--- a/src/docx/parse/properties/schema/measure.rs
+++ b/src/docx/parse/properties/schema/measure.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::docx::model::dimension::{Dimension, FiftiethPercent};
 use crate::docx::model::TableMeasure;
-use crate::docx::parse::primitives::integer_measure::IntegerMeasure;
+use crate::docx::parse::primitives::integer_measure::{IntegerMeasure, MeasureKind};
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -66,6 +66,25 @@ impl From<TableMeasureXml> for TableMeasure {
     }
 }
 
+impl TableMeasureXml {
+    /// Whether `From<TableMeasureXml> for TableMeasure` (above) discards
+    /// `@w` for this element: `@type` never reads it at all (`auto`/`nil`),
+    /// or `@w`'s spelling contradicts `@type` (a percentage under `dxa`, a
+    /// length under `pct`). Shared with the negative-value guard below so
+    /// the two "which widths does this engine ignore" answers can't drift
+    /// apart — see that guard's doc comment for why a discarded width's sign
+    /// must not be allowed to fail the document either.
+    fn discards_w(&self, w: &IntegerMeasure) -> bool {
+        matches!(
+            (self.ty, w.kind()),
+            (StTblWidthType::Auto, _)
+                | (StTblWidthType::Nil, _)
+                | (StTblWidthType::Dxa, MeasureKind::Percent)
+                | (StTblWidthType::Pct, MeasureKind::Universal)
+        )
+    }
+}
+
 /// Deserialize a possibly-repeated table measurement, rejecting a negative
 /// value on the occurrence that survives.
 ///
@@ -76,32 +95,26 @@ impl From<TableMeasureXml> for TableMeasure {
 /// ignoring an element for its value while honouring it for its validity.
 /// See `crate::docx::parse::primitives::duplicates` for the collapsing policy.
 ///
-/// The same rule extends to a spelling that contradicts `@type`: the
-/// conversion below discards such a width (degrading to `Auto`), so its sign
-/// must not fail the document either — rejecting `w="-50%" type="dxa"` while
+/// The same rule extends to a width `discards_w` reports as discarded: the
+/// conversion above ignores it (degrading to `Auto`/`Nil`), so its sign must
+/// not fail the document either — rejecting `w="-50%" type="dxa"` while
 /// accepting `w="50%" type="dxa"` would again honour an ignored value for
-/// its validity.
+/// its validity, and the same goes for `auto`/`nil`, which ignore `@w`
+/// unconditionally.
 pub(crate) fn deserialize_vec_nonnegative_table_measure<'de, D>(
     deserializer: D,
 ) -> Result<Vec<TableMeasureXml>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    use crate::docx::parse::primitives::integer_measure::MeasureKind;
-
     let measures = Vec::<TableMeasureXml>::deserialize(deserializer)?;
-    if let Some(w) = measures.last().and_then(|value| value.w.as_ref()) {
-        let contradictory = measures.last().is_some_and(|value| {
-            matches!(
-                (value.ty, w.kind()),
-                (StTblWidthType::Dxa, MeasureKind::Percent)
-                    | (StTblWidthType::Pct, MeasureKind::Universal)
-            )
-        });
-        if w.is_negative() && !contradictory {
-            return Err(serde::de::Error::custom(
-                "negative value is not valid for this OOXML table measurement",
-            ));
+    if let Some(last) = measures.last() {
+        if let Some(w) = last.w.as_ref() {
+            if w.is_negative() && !last.discards_w(w) {
+                return Err(serde::de::Error::custom(
+                    "negative value is not valid for this OOXML table measurement",
+                ));
+            }
         }
     }
     Ok(measures)
@@ -236,6 +249,33 @@ mod tests {
             TableMeasure::Pct(d) => assert_eq!(d.raw(), 1),
             other => panic!("expected Pct, got {other:?}"),
         }
+    }
+
+    /// `auto`/`nil` discard `@w` unconditionally — `TableMeasureXml::from`
+    /// never reads it for either type — so a negative spelling under either
+    /// must degrade rather than fail the document, the same rule that
+    /// already applies to a spelling that contradicts `@type`.
+    #[test]
+    fn auto_and_nil_negative_widths_degrade_without_failing() {
+        let ok: Result<NonnegativeTableMeasure, _> =
+            quick_xml::de::from_str(r#"<x><tblW w="-50%"/></x>"#);
+        let value = ok.expect("an auto width's sign must not be fatal");
+        assert!(matches!(
+            crate::model::Dup::from(value.value)
+                .into_value()
+                .map(TableMeasure::from),
+            Some(TableMeasure::Auto)
+        ));
+
+        let ok: Result<NonnegativeTableMeasure, _> =
+            quick_xml::de::from_str(r#"<x><tblW w="-1in" type="nil"/></x>"#);
+        let value = ok.expect("a nil width's sign must not be fatal");
+        assert!(matches!(
+            crate::model::Dup::from(value.value)
+                .into_value()
+                .map(TableMeasure::from),
+            Some(TableMeasure::Nil)
+        ));
     }
 
     #[test]

--- a/src/docx/parse/properties/schema/run.rs
+++ b/src/docx/parse/properties/schema/run.rs
@@ -35,6 +35,14 @@ impl<'de> Deserialize<'de> for TextScaleXml {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = String::deserialize(deserializer)?;
         let head = raw.strip_suffix('%').unwrap_or(&raw);
+        // §22.9.2.9/§17.18.81 admit no `+` sign — matches the rejection
+        // every other percent/universal-measure spelling in this codebase
+        // applies (`parse_decimal_scaled`'s `allow_plus: false`).
+        if head.starts_with('+') {
+            return Err(serde::de::Error::custom(
+                "expected a §17.18.81 text-scale percentage",
+            ));
+        }
         head.parse::<u16>()
             .map(TextScaleXml)
             .map_err(|_| serde::de::Error::custom("expected a §17.18.81 text-scale percentage"))
@@ -401,6 +409,17 @@ mod tests {
         let (rp, _) = parse(r#"<rPr><w val="80"/></rPr>"#);
         assert_eq!(rp.text_scale, Dup::from(Some(TextScale::new(80))));
         assert_eq!(rp.text_scale.cloned().unwrap().percent(), 80);
+    }
+
+    #[test]
+    fn text_scale_rejects_plus_sign() {
+        // §17.18.81/§22.9.2.9 admit no `+` sign — matches the rejection
+        // every other percent/universal-measure spelling in this codebase
+        // applies (see units.rs's `percent_sign_travels_and_plus_is_rejected`).
+        let parsed: Result<RPrXml, _> = quick_xml::de::from_str(r#"<rPr><w val="+80%"/></rPr>"#);
+        assert!(parsed.is_err(), "a leading + must be rejected");
+        let parsed: Result<RPrXml, _> = quick_xml::de::from_str(r#"<rPr><w val="+80"/></rPr>"#);
+        assert!(parsed.is_err(), "a leading + must be rejected");
     }
 
     #[test]


### PR DESCRIPTION
Replace the universal unit function with a constant array for EMU ratios to enhance maintainability. Improve SideXml deserialization to correctly handle width types and add tests to ensure proper functionality.